### PR TITLE
feat: SubVerso support for using a name as an example

### DIFF
--- a/demo/Demo.lean
+++ b/demo/Demo.lean
@@ -28,3 +28,5 @@ theorem test (n : Nat) : n * 1 = n := by
 def test2 [ToString α] (x : α) : Decidable (toString x = "") := by
   constructor; sorry
 %end
+
+%show_name Nat.rec


### PR DESCRIPTION
This makes it easier to just refer to a name in the text.