### PR TITLE
fix: missing warnings from some examples

### DIFF
--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -60,17 +60,17 @@ theorem test (n : Nat) : n * 1 = n := by
 
 open Lean Elab Command in
 elab "#evalString" s:str e:term : command => do
-  let msgs ← MonadMessageState.getMessages
+  let msgs := (← get).messages
   try
-    MonadMessageState.setMessages {}
+    modify ({· with messages := {}})
     elabCommand <| ← `(#eval $e)
-    let msgs' ← MonadMessageState.getMessages
+    let msgs' := (← get).messages
     let [msg] := msgs'.toList
       | throwError "Too many messages"
     if (← msg.toString) != s.getString then
       throwErrorAt e "Expected {String.quote s.getString}, got {String.quote (← msg.toString)}"
   finally
-    MonadMessageState.setMessages msgs
+    modify ({· with messages := msgs})
 
 #evalString "[[\"n * 1 = n\"]]\n"
   (proofEx.highlighted[0].proofStates.data.filter (·.fst == "by") |>.map (·.snd.data.map (·.conclusion)))

--- a/demo-toml/Demo.lean
+++ b/demo-toml/Demo.lean
@@ -31,3 +31,12 @@ theorem test (n : Nat) : n * 1 = n := by
 def test2 [ToString α] (x : α) : Decidable (toString x = "") := by
   constructor; sorry
 %end
+
+%show_name Nat.rec
+
+%signature qs
+  Array.qsort.{u} {α : Type u} (as : Array α) (lt : α → α → Bool) (low : Nat := 0) (high : Nat := as.size - 1) : Array α
+
+%example hasSorry
+theorem bogus : 2 = 2 := by sorry
+%end

--- a/demo/Demo.lean
+++ b/demo/Demo.lean
@@ -36,3 +36,12 @@ def test2 [ToString α] (x : α) : Decidable (toString x = "") := by
 
 %signature qs
   Array.qsort.{u} {α : Type u} (as : Array α) (lt : α → α → Bool) (low : Nat := 0) (high : Nat := as.size - 1) : Array α
+
+%example hasSorry
+theorem bogus : 2 = 2 := by sorry
+%end
+
+%example linted
+def g : α → Nat
+  | x => 3
+%end


### PR DESCRIPTION
Examples with linter warnings weren't being extracted, because the linters were run after the example extraction process. Linters are now run redundantly to work around this.