### PR TITLE
feat: save definition sites in code examples

### DIFF
--- a/src/compat/SubVerso/Compat.lean
+++ b/src/compat/SubVerso/Compat.lean
@@ -116,6 +116,11 @@ def rwTacticRightBracket? (stx : Syntax) : Option Syntax := Id.run do
 def getDeclarationRange? [Monad m] [MonadFileMap m] (stx : Syntax) : m (Option DeclarationRange) :=
   %first_succeeding [Lean.Elab.getDeclarationRange? stx, some <$> Lean.Elab.getDeclarationRange stx]
 
+namespace NameSet
+def union (xs ys : NameSet) : NameSet :=
+  xs.mergeBy (fun _ _ _ => .unit) ys
+end NameSet
+
 namespace List
 -- bind was renamed to flatMap in 4.14
 def flatMap (xs : List α) (f : α → List β) : List β :=

--- a/src/compat/SubVerso/Compat.lean
+++ b/src/compat/SubVerso/Compat.lean
@@ -113,6 +113,9 @@ def rwTacticRightBracket? (stx : Syntax) : Option Syntax := Id.run do
   return none
 
 
+def getDeclarationRange? [Monad m] [MonadFileMap m] (stx : Syntax) : m (Option DeclarationRange) :=
+  %first_succeeding [Lean.Elab.getDeclarationRange? stx, some <$> Lean.Elab.getDeclarationRange stx]
+
 namespace List
 -- bind was renamed to flatMap in 4.14
 def flatMap (xs : List α) (f : α → List β) : List β :=

--- a/src/highlighting/SubVerso/Highlighting/Code.lean
+++ b/src/highlighting/SubVerso/Highlighting/Code.lean
@@ -195,7 +195,7 @@ def isDefinition [Monad m] [MonadEnv m] [MonadLiftT IO m] [MonadFileMap m] (name
   -- yet, but they're a more marginal use case - there's no name to hyperlink to them in rendered
   -- HTML.
   if !((← getEnv).isConstructor name || (← getEnv).isProjectionFn name || stx.getKind == ``Parser.Command.declId) then return false
-  if stx.getHeadInfo == .none then return false
+  if let .none := stx.getHeadInfo then return false
   let ranges :=
     if let some r := (← findDeclarationRangesCore? name) then
       some r

--- a/src/highlighting/SubVerso/Highlighting/Highlighted.lean
+++ b/src/highlighting/SubVerso/Highlighting/Highlighted.lean
@@ -6,6 +6,7 @@ Author: David Thrane Christiansen
 import Lean.Data.Json
 import Lean.Expr
 import Lean.SubExpr -- for the To/FromJSON FVarId instances
+import SubVerso.Compat
 
 open Lean
 
@@ -135,7 +136,7 @@ partial def Highlighted.definedNames : Highlighted → NameSet
     | .const n _ _ true => NameSet.empty.insert n
     | _ => {}
   | .span _ hl | .tactics _ _ _ hl => hl.definedNames
-  | .seq hls => hls.map (·.definedNames) |>.foldr NameSet.append {}
+  | .seq hls => hls.map (·.definedNames) |>.foldr Compat.NameSet.union {}
   | .text .. | .point .. => {}
 
 open Lean Syntax in

--- a/src/highlighting/SubVerso/Highlighting/Highlighted.lean
+++ b/src/highlighting/SubVerso/Highlighting/Highlighted.lean
@@ -41,7 +41,7 @@ private local instance : FromJson Name := ⟨altNameUnJson⟩
 inductive Token.Kind where
   | /-- `occurrence` is a unique identifier that unites the various keyword tokens from a given production -/
     keyword (name : Option Name) (occurrence : Option String) (docs : Option String)
-  | const (name : Name) (signature : String) (docs : Option String)
+  | const (name : Name) (signature : String) (docs : Option String) (isDef : Bool)
   | anonCtor (name : Name) (signature : String) (docs : Option String)
   | var (name : FVarId) (type : String)
   | str (string : String)
@@ -56,7 +56,7 @@ open Syntax (mkCApp) in
 instance : Quote Token.Kind where
   quote
     | .keyword n occ docs => mkCApp ``keyword #[quote n, quote occ, quote docs]
-    | .const n sig docs => mkCApp ``const #[quote n, quote sig, quote docs]
+    | .const n sig docs isDef => mkCApp ``const #[quote n, quote sig, quote docs, quote isDef]
     | .anonCtor n sig docs => mkCApp ``anonCtor #[quote n, quote sig, quote docs]
     | .option n d docs => mkCApp ``option #[quote n, quote d, quote docs]
     | .var (.mk n) type => mkCApp ``var #[mkCApp ``FVarId.mk #[quote n], quote type]
@@ -120,6 +120,7 @@ inductive Highlighted where
 deriving Repr, Inhabited, BEq, Hashable, ToJson, FromJson
 
 def Highlighted.empty : Highlighted := .seq #[]
+
 instance : Append Highlighted where
   append
     | .text str1, .text str2 => .text (str1 ++ str2)
@@ -127,6 +128,15 @@ instance : Append Highlighted where
     | .seq xs,  x => .seq (xs ++ #[x])
     | x, .seq xs => .seq (#[x] ++ xs)
     | x, y => .seq #[x, y]
+
+partial def Highlighted.definedNames : Highlighted → NameSet
+  | .token ⟨tok, _⟩ =>
+    match tok with
+    | .const n _ _ true => NameSet.empty.insert n
+    | _ => {}
+  | .span _ hl | .tactics _ _ _ hl => hl.definedNames
+  | .seq hls => hls.map (·.definedNames) |>.foldr NameSet.append {}
+  | .text .. | .point .. => {}
 
 open Lean Syntax in
 open Highlighted in


### PR DESCRIPTION
This is preparatory work for getting the examples in Markdown docstrings to render properly.