### PR TITLE
chore: bump for 2025-03-16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           - "4.18.0-rc1"
           - "nightly-2025-03-06"
           - "nightly-2025-03-12"
+          - "nightly-2025-03-16"
         platform:
           - os: ubuntu-latest
             installer: |

--- a/src/examples/SubVerso/Examples.lean
+++ b/src/examples/SubVerso/Examples.lean
@@ -108,7 +108,7 @@ macro_rules
 deriving instance Repr for MessageSeverity
 
 elab_rules : command
-  | `(%example%$tk ( config := $cfg:term ) $name:ident $cmd $cmds* %end) => do
+  | `(%example%$tk ( config := $cfg:term ) $name:ident $cmd $cmds* %end) => Compat.commandWithoutAsync do
     let config ← liftTermElabM <| elabExampleConfig cfg
     let allCommands := #[cmd] ++ cmds
     let (allCommands, termExamples) := allCommands.mapM extractExamples .empty


### PR DESCRIPTION
Async elaboration of theorems means that proof states are not necessarily available in the info tree when command elaboration returns. It needs to be disabled for highlighted code, so that it's working with complete information.