### PR TITLE
perf: spend less time looking for proof states

### DIFF
--- a/ExtractModule.lean
+++ b/ExtractModule.lean
@@ -45,7 +45,11 @@ unsafe def main : (args : List String) → IO UInt32
       for cmd in #[headerStx] ++ cmdStx do
         let hl ← (Frontend.runCommandElabM <| liftTermElabM <| highlight cmd msgs infos) pctx cmdSt
         let defs := hl.definedNames.toArray.map (·.toString)
-        hls := hls.push <| json%{"defines": $defs, "kind": $(cmd.getKind), "code": $(ToJson.toJson hl)}
+        hls := hls.push <| Json.mkObj [
+          ("defines", ToJson.toJson defs),
+          ("kind", ToJson.toJson cmd.getKind),
+          ("code", ToJson.toJson hl)
+        ]
       if let some p := (outFile : System.FilePath).parent then
         IO.FS.createDirAll p
       IO.FS.writeFile outFile (toString (Json.arr hls) ++ "\n")

--- a/ExtractModule.lean
+++ b/ExtractModule.lean
@@ -41,12 +41,14 @@ unsafe def main : (args : List String) → IO UInt32
       let infos := (← cmdSt.get).commandState.infoState.trees
       let msgs := Compat.messageLogArray (← cmdSt.get).commandState.messages
 
-      let mut hls := Highlighted.empty
+      let mut hls : Array Json := #[]
       for cmd in #[headerStx] ++ cmdStx do
-        hls := hls ++ (← (Frontend.runCommandElabM <| liftTermElabM <| highlight cmd msgs infos) pctx cmdSt)
+        let hl ← (Frontend.runCommandElabM <| liftTermElabM <| highlight cmd msgs infos) pctx cmdSt
+        let defs := hl.definedNames.toArray.map (·.toString)
+        hls := hls.push <| json%{"defines": $defs, "kind": $(cmd.getKind), "code": $(ToJson.toJson hl)}
       if let some p := (outFile : System.FilePath).parent then
         IO.FS.createDirAll p
-      IO.FS.writeFile outFile (toString (ToJson.toJson hls) ++ "\n")
+      IO.FS.writeFile outFile (toString (Json.arr hls) ++ "\n")
       return (0 : UInt32)
 
     catch e =>

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -36,6 +36,8 @@ partial def SubVerso.Highlighting.Highlighted.proofStates (hl : Highlighting.Hig
   | _ => pure ()
   out
 
+set_option pp.rawOnError true
+
 %example proof
 theorem test (n : Nat) : n * 1 = n := by
   induction n with
@@ -54,6 +56,26 @@ theorem test (n : Nat) : n * 1 = n := by
 
 %dumpE proof into proofEx
 
+%example proof2
+example :
+    (fun (x y z : Nat) =>
+      x + (y + z))
+    =
+    (fun x y z =>
+      (z + x) + y)
+  := by
+  conv =>
+    lhs
+    intro x y z
+    conv =>
+      arg 2
+      rw [Nat.add_comm]
+    rw [← Nat.add_assoc]
+    arg 1
+    rw [Nat.add_comm]
+%end
+
+%dumpE proof2 into proofEx2
 
 
 -- We don't have #guard_msgs in all supported Lean versions, so here's a low-tech replacement:
@@ -96,7 +118,5 @@ elab "#evalStrings " "[" ss:str,* "] " e:term : command => do
     "[[some `zero], [some `succ], [none], [some `succ.succ], [none]]\n",
     "[[none], [some `succ.succ], [none]]\n"]
  (proofEx.highlighted[0].proofStates.toList.filter (·.fst == "=>") |>.map (·.snd.toList.map (·.name)))
-
-
 
 def main : IO Unit := pure ()

--- a/src/SubVerso/Compat.lean
+++ b/src/SubVerso/Compat.lean
@@ -8,6 +8,14 @@ import Lean.Util.Paths
 
 open Lean Elab Term
 
+-- This was introduced in #3159, so we need a shim:
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  if !(← getEnv).contains `Lean.Elab.PartialContextInfo then
+    dbg_trace "lkj"
+    let cmd ← `(def $(mkIdent `Lean.Elab.ContextInfo.mergeIntoOuter?) (inner: ContextInfo) (_outer : Option ContextInfo) : ContextInfo := inner)
+    elabCommand cmd
+
 namespace SubVerso.Compat
 
 elab "%first_defined" "[" xs:ident,* "]" : term => do


### PR DESCRIPTION
Also updates the output format of subverso-extract-mod to be split by declaration.