### PR TITLE
chore: bump to 2025-04-14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
           - "nightly-2025-03-29"
           - "nightly-2025-03-30"
           - "nightly-2025-04-09"
+          - "nightly-2025-04-14"
         platform:
           - os: ubuntu-latest
             installer: |

--- a/src/SubVerso/Compat.lean
+++ b/src/SubVerso/Compat.lean
@@ -176,13 +176,15 @@ def getDeclarationRange? [Monad m] [MonadFileMap m] (stx : Syntax) : m (Option D
 
 def messageLogArray (msgs : Lean.MessageLog) : Array Lean.Message := %first_succeeding [msgs.toArray, msgs.msgs.toArray]
 
+set_option linter.unusedVariables false in
 def initSrcSearchPath (pkgSearchPath : SearchPath := ∅) : IO SearchPath := do
   %first_succeeding [
     Lean.initSrcSearchPath (pkgSearchPath := pkgSearchPath),
     Lean.initSrcSearchPath (sp := pkgSearchPath),
     -- leanSysRoot seems to never have been used by this function
     Lean.initSrcSearchPath (leanSysroot := "") (sp := pkgSearchPath),
-    Lean.initSrcSearchPath (_leanSysroot := "") (sp := pkgSearchPath)
+    Lean.initSrcSearchPath (_leanSysroot := "") (sp := pkgSearchPath),
+    Lean.getSrcSearchPath
   ]
 
 namespace NameSet


### PR DESCRIPTION
This makes SubVerso compatible with Lean after https://github.com/leanprover/lean4/pull/7873