### PR TITLE
feat: tag messages as having originally been errors

### DIFF
--- a/src/SubVerso/Compat.lean
+++ b/src/SubVerso/Compat.lean
@@ -292,6 +292,12 @@ def getDeclarationRange? [Monad m] [MonadFileMap m] (stx : Syntax) : m (Option D
 
 def messageLogArray (msgs : Lean.MessageLog) : Array Lean.Message := %first_succeeding [msgs.toArray, msgs.msgs.toArray]
 
+def mapMessages (msgLog : Lean.MessageLog) (f : Lean.Message → Lean.Message) : Lean.MessageLog :=
+  %first_succeeding [
+    { msgLog with msgs := msgLog.msgs.map f },
+    { msgLog with unreported := msgLog.unreported.map f }
+  ]
+
 set_option linter.unusedVariables false in
 def initSrcSearchPath (pkgSearchPath : SearchPath := ∅) : IO SearchPath := do
   %first_succeeding [

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -1,5 +1,5 @@
 /-
-Copyright (c) 2023-2024 Lean FRO LLC. All rights reserved.
+Copyright (c) 2023-2025 Lean FRO LLC. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
@@ -9,6 +9,7 @@ import Lean.Widget.TaggedText
 
 import SubVerso.Compat
 import SubVerso.Highlighting.Highlighted
+import SubVerso.Highlighting.Messages
 
 open Lean hiding perhaps (HashMap)
 open Elab
@@ -17,7 +18,6 @@ open Lean.Widget
 open Lean.PrettyPrinter (InfoPerPos)
 open SubVerso.Compat (HashMap)
 
---initialize registerTraceClass `SubVerso.Highlighting.Code
 
 namespace SubVerso.Highlighting
 
@@ -571,13 +571,14 @@ def needsOpening (pos : Lean.Position) (message : MessageBundle) : Bool :=
 def needsClosing (pos : Lean.Position) (message : MessageBundle) : Bool :=
   message.endPos.map pos.notAfter |>.getD true
 
+
 partial def openUntil (pos : Lean.Position) : HighlightM Unit := do
   if let some msg ← nextMessage? then
     if needsOpening pos msg then
       advanceMessages
       let str ← msg.messages.mapM fun m => do
           let kind : Highlighted.Span.Kind :=
-            match m.severity with
+            match SubVerso.Highlighting.Messages.severity m with
             | .error => .error
             | .warning => .warning
             | .information => .info

--- a/src/SubVerso/Highlighting/Messages.lean
+++ b/src/SubVerso/Highlighting/Messages.lean
@@ -26,20 +26,8 @@ def errorsToWarnings (log : MessageLog) : MessageLog :=
         | MessageSeverity.error => { m with severity := MessageSeverity.warning, data := originallyError m.data }
         | _ => m
 
-open MessageData in
-partial def getTags : MessageData → List Name
-  | withContext _ msg       => getTags msg
-  | withNamingContext _ msg => getTags msg
-  | nest _ msg              => getTags msg
-  | group msg               => getTags msg
-  | compose msg₁ msg₂       => getTags msg₁ ++ getTags msg₂
-  | tagged n msg            => n :: getTags msg
-  | .trace data msg msgs     => data.cls :: getTags msg ++ msgs.toList.flatMap getTags
-  | _                       => []
-
-
+/--
+Gets the severity of a message, taking recorded original severities into account.
+-/
 def severity (msg : Message) : MessageSeverity :=
-  dbg_trace "HEY! {getTags msg.data} {msg.data.hasTag (· == originalErrorTag)}"
-  if msg.data.hasTag (· == originalErrorTag) then
-    .error
-  else msg.severity
+  if msg.data.hasTag (· == originalErrorTag) then .error else msg.severity

--- a/src/SubVerso/Highlighting/Messages.lean
+++ b/src/SubVerso/Highlighting/Messages.lean
@@ -1,0 +1,28 @@
+/-
+Copyright (c) 2023-2025 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+import Lean.Message
+
+namespace SubVerso.Highlighting.Messages
+
+open Lean
+
+/--
+Marks a message as originally having been an error, even if it was downgraded to a warning.
+-/
+def originallyError (msg : MessageData) : MessageData := .tagged `SubVerso.originallyError msg
+
+/--
+Converts the errors in a message log into warnings, recording that they were originally errors for later reconstruction.
+-/
+def errorsToWarnings (log : MessageLog) : MessageLog :=
+  { msgs := log.msgs.map fun m =>
+      match m.severity with
+        | MessageSeverity.error => { m with severity := MessageSeverity.warning, data := originallyError m.data }
+        | _ => m
+  }
+
+def severity (msg : Message) : MessageSeverity :=
+  if msg.data.hasTag (· == `SubVerso.originallyError) then .error else msg.severity

--- a/src/SubVerso/Highlighting/Messages.lean
+++ b/src/SubVerso/Highlighting/Messages.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Author: David Thrane Christiansen
 -/
 import Lean.Message
+import SubVerso.Compat
 
 namespace SubVerso.Highlighting.Messages
 
@@ -18,11 +19,11 @@ def originallyError (msg : MessageData) : MessageData := .tagged `SubVerso.origi
 Converts the errors in a message log into warnings, recording that they were originally errors for later reconstruction.
 -/
 def errorsToWarnings (log : MessageLog) : MessageLog :=
-  { msgs := log.msgs.map fun m =>
+  SubVerso.Compat.mapMessages log fun m =>
       match m.severity with
         | MessageSeverity.error => { m with severity := MessageSeverity.warning, data := originallyError m.data }
         | _ => m
-  }
+
 
 def severity (msg : Message) : MessageSeverity :=
   if msg.data.hasTag (· == `SubVerso.originallyError) then .error else msg.severity


### PR DESCRIPTION
This allows them to be downgraded to warnings while interacting with example files, while still rendering them reliably as errors later.