### PR TITLE
feat: add highlighting mode that includes unparsed syntax

### DIFF
--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -194,20 +194,18 @@ end
 /-! # Highlighting Unparsed Spans -/
 section HighlightUnparsed
 
-local syntax "foo" : command
-
-partial def hlMsgString : Highlighting.Highlighted → String
-  | .seq xs => xs.foldl (init := "") (fun s hl => s ++ hlMsgString hl)
+partial def hlStringWithMessages : Highlighting.Highlighted → String
+  | .seq xs => xs.foldl (init := "") (fun s hl => s ++ hlStringWithMessages hl)
   | .point .. => ""
-  | .tactics _ _ _ x => hlMsgString x
+  | .tactics _ _ _ x => hlStringWithMessages x
   | .span info x =>
     let labels := info.map fun (k, s) => s!"{k}: {s}"
     let labelStr := ", ".intercalate labels.toList
-    s!"[{labelStr}]({hlMsgString x})"
+    s!"[{labelStr}]({hlStringWithMessages x})"
   | .text s | .token ⟨_, s⟩ | .unparsed s => s
 
 open Lean Elab Command in
-def mkHighlightStr (input : String) (msgPrefix := "subverso_test")
+def highlightWithPrefixedMessages (input : String) (msgPrefix := "subverso_test")
     : CommandElabM Highlighting.Highlighted := do
   let inputCtx := Parser.mkInputContext input "<input>"
   let commandState : Command.State := {
@@ -237,9 +235,9 @@ discrepancies).
 -/
 elab "#evalHighlight" inp:str exp:str : command => do
   let input := inp.getString
-  let hl ← mkHighlightStr input
+  let hl ← highlightWithPrefixedMessages input
   let expected := exp.getString
-  let hlStr := hlMsgString hl
+  let hlStr := hlStringWithMessages hl
   if hlStr != expected then
     throwError m!"Mismatched output\n---Found:---\n{hlStr}\n\n---Expected:---\n{expected}"
 

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -20,6 +20,7 @@ partial def SubVerso.Highlighting.Highlighted.asString (hl : Highlighted) : Stri
     out := out ++ hl'.asString
   | .point .. => pure ()
   | .text s => out := out ++ s
+  | .unparsed s => out := out ++ s
   | .token t => out := out ++ t.content
   out
 

--- a/src/SubVerso/Compat.lean
+++ b/src/SubVerso/Compat.lean
@@ -402,6 +402,13 @@ def keys {_ : BEq α} {_ : Hashable α} (xs : HashMap α β) : List α:=
 
 end HashMap
 
+namespace HashSet
+
+instance [BEq α] [Hashable α] : EmptyCollection (HashSet α) :=
+  ⟨%first_succeeding [Std.HashSet.emptyWithCapacity, Std.HashSet.empty, Lean.HashSet.empty]⟩
+
+end HashSet
+
 -- In nightly-2025-02-13, simp_arith became an error. Falling back to the old version is complicated
 -- because there's no fully-backwards-compatible syntax to use here that works all the way back to Lean 4.0.0.
 open Lean Elab Command in

--- a/src/SubVerso/Highlighting/Anchors.lean
+++ b/src/SubVerso/Highlighting/Anchors.lean
@@ -104,6 +104,7 @@ private partial def normHl : Highlighted → Highlighted
   | .text "" => .empty
   | .text s => .text s
   | .token t => .token t
+  | .unparsed s => .unparsed s
 
 private inductive HlCtx where
   | tactics (info : Array (Highlighted.Goal Highlighted)) (startPos endPos : Nat)
@@ -205,7 +206,7 @@ private def Hl.tacticsAt? (hl : Hl) (column : Nat) : Option Highlighted := do
       left := .empty
       right := .empty
       focus := x
-    | .text s =>
+    | .text s | .unparsed s =>
       let lines := getLines s
       if lines.size > 1 then -- found a line break
         right := .text (Compat.Array.back! lines) ++ right
@@ -244,7 +245,7 @@ private def Hl.tacticsAt? (hl : Hl) (column : Nat) : Option Highlighted := do
         match hl with
         | .seq xs =>
           line := xs.toList.map .inl ++ more
-        | .text s | .token ⟨_, s⟩ =>
+        | .text s | .token ⟨_, s⟩ | .unparsed s =>
           if s.length > column then
             break
           else
@@ -362,7 +363,7 @@ def anchored (hl : Highlighted) (textAnchors := true) (proofStates := true) : Ex
             anchorOut := anchorOut.insert a hl.toHighlighted
             openAnchors := openAnchors.erase a
           else throw s!"Anchor not open: {a}"
-    | some h@(.token ..) :: hs | some h@(.point ..) :: hs =>
+    | some h@(.token ..) :: hs | some h@(.point ..) :: hs | some h@(.unparsed ..) :: hs =>
       todo := hs
       openAnchors := openAnchors.map fun _ hl => hl ++ h
       doc := doc ++ h

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -428,6 +428,9 @@ def Output.add (output : List Output) (hl : Highlighted) : List Output :=
 def Output.addToken (output : List Output) (token : Token) : List Output :=
   Output.add output (.token token)
 
+def Output.addUnparsed (output : List Output) (text : String) : List Output :=
+  Output.add output (.unparsed text)
+
 def Output.openSpan (output : List Output) (messages : Array (Highlighted.Span.Kind × String)) (startPos : String.Pos) (endPos : Option String.Pos) : List Output :=
   match output with
   | t@(.tactics _ start stop) :: output' =>
@@ -754,7 +757,7 @@ def fillMissingSourceUpTo (pos : String.Pos) : HighlightM Unit := do
         let endPos := boundaries[i]'h.2
         openUntil <| text.toPosition startPos
         let string := Substring.mk text.source startPos endPos |>.toString
-        modify fun st => {st with output := Output.addText st.output string}
+        modify fun st => {st with output := Output.addUnparsed st.output string}
         closeUntil endPos
         setLastPos endPos
 

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -684,6 +684,7 @@ def fillMissingSourceUpTo (pos : String.Pos) : HighlightM Unit := do
       let string := Substring.mk text.source lastPos pos |>.toString
       modify fun st => {st with output := Output.addText st.output string}
       closeUntil pos
+      setLastPos pos
 
 def emitString (pos endPos : String.Pos) (string : String) : HighlightM Unit := do
   fillMissingSourceUpTo pos

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -751,10 +751,9 @@ def fillMissingSourceUpTo (pos : String.Pos) : HighlightM Unit := do
       let boundaries ← collectMessageBoundariesBetween lastPos pos
       let boundaries := boundaries.insertMany #[lastPos, pos]
       let boundaries := boundaries.toArray.qsort (· < ·)
-      for h : i in [1 : boundaries.size] do
-        have : i - 1 < boundaries.size := Nat.lt_of_le_of_lt (Nat.sub_le i 1) h.2
-        let startPos := boundaries[i - 1]
-        let endPos := boundaries[i]'h.2
+      for i in [1 : boundaries.size] do
+        let startPos := boundaries[i - 1]!
+        let endPos := boundaries[i]!
         openUntil <| text.toPosition startPos
         let string := Substring.mk text.source startPos endPos |>.toString
         modify fun st => {st with output := Output.addUnparsed st.output string}

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -674,9 +674,11 @@ partial def closeUntil (pos : String.Pos) : HighlightM Unit := do
 
   if more then closeUntil pos
 
+/-- Records the corresponding source position of the syntax most recently added to the output. -/
 def setLastPos (lastPos? : Option String.Pos) : HighlightM Unit := do
   modify fun st => { st with lastPos? }
 
+/-- Adds to the output any source (if any exists) lying between the last added position and `pos`. -/
 def fillMissingSourceUpTo (pos : String.Pos) : HighlightM Unit := do
   if let some lastPos := (← get).lastPos? then
     if lastPos < pos then

--- a/src/SubVerso/Highlighting/Highlighted.lean
+++ b/src/SubVerso/Highlighting/Highlighted.lean
@@ -147,6 +147,14 @@ inductive Highlighted.Span.Kind where
   | info
 deriving Repr, DecidableEq, Inhabited, BEq, Hashable, ToJson, FromJson
 
+def Highlighted.Span.Kind.toString : Highlighted.Span.Kind → String
+  | .error => "error"
+  | .warning => "warning"
+  | .info => "info"
+
+instance : ToString Highlighted.Span.Kind where
+  toString := Highlighted.Span.Kind.toString
+
 open Highlighted Span Kind in
 open Syntax in
 instance : Quote Kind where

--- a/src/SubVerso/Highlighting/Split.lean
+++ b/src/SubVerso/Highlighting/Split.lean
@@ -59,7 +59,7 @@ def Highlighted.split (p : String → Bool) (hl : Highlighted) : Array Highlight
         current := .empty
       else
         current := current ++ this
-    | some this@(.text ..) :: hs | some this@(.point ..) :: hs =>
+    | some this@(.text ..) :: hs | some this@(.point ..) :: hs | some this@(.unparsed ..) :: hs =>
       todo := hs
       current := current ++ this
     | some (.span msgs x) :: hs =>
@@ -93,7 +93,7 @@ def Highlighted.lines (hl : Highlighted) : Array Highlighted := Id.run do
     | some this@(.token ..) :: hs =>
       todo := hs
       current := current ++ this
-    | some this@(.text str) :: hs =>
+    | some this@(.text str) :: hs | some this@(.unparsed str) :: hs =>
       if str.contains '\n' then
         let pre := str.takeWhile (· ≠ '\n') ++ "\n"
         let post := str.drop pre.length

--- a/src/SubVerso/Highlighting/String.lean
+++ b/src/SubVerso/Highlighting/String.lean
@@ -17,7 +17,7 @@ Name tokens are those with kind `const` or `var`.
 partial def matchingName? (hl : Highlighted) (name : String) : Option Token := do
   match hl with
   | .seq xs => xs.findSome? (matchingName? · name)
-  | .point .. | .text .. => none
+  | .point .. | .text .. | .unparsed .. => none
   | .tactics _ _ _ x | .span _ x => matchingName? x name
   | .token t@⟨k, s⟩ =>
     match k with
@@ -40,7 +40,7 @@ partial def firstToken (hl : Highlighted) : Option (Highlighted × Highlighted) 
         else continue
       else failure
     failure
-  | .point .. | .text .. => none
+  | .point .. | .text .. | .unparsed .. => none
   | .tactics _ _ _ x | .span _ x => firstToken x
   | .token .. => pure (hl, .empty)
 


### PR DESCRIPTION
This PR adds a `highlightIncludingUnparsed` method to the `Highlighting` module, which will insert unparsed syntax regions into the output `Highlighted` value. Unparsed regions are determined using the positions on the input syntax and are filled in using the file map. This is useful for demonstrating parsing errors alongside elaboration errors in a single code block.