### PR TITLE
chore: update to nightly-2025-10-05

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           - "4.23.0"
           - "4.24.0-rc1"
           - "nightly-2025-09-26"
+          - "nightly-2025-10-05"
 
         platform:
           - os: nscloud-ubuntu-22.04-amd64-8x16

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -215,7 +215,7 @@ def highlightWithPrefixedMessages (input : String) (msgPrefix := "subverso_test"
   let (_, { commandState, commands, .. }) ← Frontend.processCommands
     |>.run { inputCtx } |>.run { commandState, parserState := {}, cmdPos := 0 }
   let mut hls : Highlighting.Highlighted := .empty
-  let mut lastPos : String.Pos := 0
+  let mut lastPos : Compat.String.Pos := 0
   for stx in commands do
     let hl ← runTermElabM fun _ =>
       withTheReader Core.Context (fun ctx => { ctx with fileMap := inputCtx.fileMap }) do

--- a/src/SubVerso/Examples.lean
+++ b/src/SubVerso/Examples.lean
@@ -489,8 +489,8 @@ Check the signature by elaborating and comparing.
 -/
 def checkSignature
     (sigName : TSyntax `Lean.Parser.Command.declId)
-    (sig : TSyntax `Lean.Parser.Command.declSig)
-    : CommandElabM (Array Highlighted × String × String.Pos × String.Pos) := do
+    (sig : TSyntax `Lean.Parser.Command.declSig) :
+    CommandElabM (Array Highlighted × String × Compat.String.Pos × Compat.String.Pos) := do
   let (sig, termExamples) := extractExamples sig .empty
   let sig : TSyntax `Lean.Parser.Command.declSig := ⟨sig⟩
 

--- a/src/SubVerso/Examples/Slice.lean
+++ b/src/SubVerso/Examples/Slice.lean
@@ -12,7 +12,7 @@ import SubVerso.Examples.Slice.Attribute
 
 open Lean (SourceInfo Syntax Environment FileMap MonadEnv MonadError MonadFileMap getFileMap getEnv nullKind)
 
-open SubVerso.Compat (Parsec HashMap)
+open SubVerso.Compat (Parsec HashMap String.Pos)
 
 namespace SubVerso.Examples.Slice
 
@@ -161,7 +161,7 @@ private partial def removeRanges (env : Environment) (rngs : Array String.Range)
     else pure stx
 
 private def getSlices (slices : Array SliceCommand) : Except String (HashMap String (Array String.Range)) := do
-  let mut opened : HashMap String (String.Pos) := {}
+  let mut opened : HashMap String (Compat.String.Pos) := {}
   let mut closed : HashMap String (Array String.Range) := {}
   for s in slices do
     match s with

--- a/src/SubVerso/Signature.lean
+++ b/src/SubVerso/Signature.lean
@@ -52,8 +52,8 @@ Check the signature by elaborating and comparing.
 -/
 def checkSignature
     (sigName : TSyntax ``Lean.Parser.Command.declId)
-    (sig : TSyntax ``Lean.Parser.Command.declSig)
-    : CommandElabM (Highlighted × String × String.Pos × String.Pos) := do
+    (sig : TSyntax ``Lean.Parser.Command.declSig) :
+    CommandElabM (Highlighted × String × Compat.String.Pos × Compat.String.Pos) := do
   let sig : TSyntax `Lean.Parser.Command.declSig := ⟨sig⟩
 
   -- First make sure the names won't clash - we want two different declarations to compare.


### PR DESCRIPTION
Works around the upstream deprecation of String.Pos by introducing a wrapper definition that detects that deprecation and selects the appropriate name accordingly.