### PR TITLE
feat: lexical(ish) tokens

### DIFF
--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -399,6 +399,24 @@ elab "#assertHasKind" inp:str kind:str : command => do
 
 open Lean Elab Command in
 /--
+`#assertAnchor inp name expected` highlights `inp` (so comments are tokenized), runs the anchor
+extractor, and checks that the anchor `name` exists and its trimmed code equals `expected`. This
+guards that `-- ANCHOR:`/`-- ANCHOR_END:` directives are still recognized after comment tokenization.
+-/
+elab "#assertAnchor" inp:str name:str expected:str : command => do
+  let hl ← highlightFromString inp.getString
+  match hl.anchored with
+  | .error e => throwError m!"anchored failed: {e}"
+  | .ok ex =>
+    match Compat.HashMap.get? ex.anchors name.getString with
+    | none => throwError m!"No anchor named {repr name.getString}"
+    | some a =>
+      let got := Compat.String.trim a.toString
+      if got != expected.getString then
+        throwError m!"Anchor {repr name.getString} = {repr got}, expected {repr expected.getString}"
+
+open Lean Elab Command in
+/--
 Checks that the token(s) with `content` carry an occurrence tag that is not attributed to an
 anonymous `null` grouping node (regression guard for null-node transparency).
 -/
@@ -465,6 +483,12 @@ elab "#assertKindRich" inp:str content:str kind:str : command => do
 #assertKind "def z :=\n  /- a /- b -/ c -/ 3" "-/" "commentDelim"
 #assertKind "def z :=\n  /- a /- b -/ c -/ 3" " a /- b -/ c " "blockComment"
 #evalHighlight' "def z :=\n  /- a /- b -/ c -/ 3" "def z :=\n  /- a /- b -/ c -/ 3"
+
+-- `-- ANCHOR:` / `-- ANCHOR_END:` directives are still recognized after comment tokenization: the
+-- anchor scanner reconstructs the comment line from its tokens.
+#assertAnchor "def pre := 0\n-- ANCHOR: foo\ndef x := 1\n-- ANCHOR_END: foo\ndef post := 2" "foo" "def x := 1"
+-- Indented directive comments are recognized too.
+#assertAnchor "def pre := 0\nsection\n  -- ANCHOR: bar\n  def x := 1\n  -- ANCHOR_END: bar\nend" "bar" "def x := 1"
 
 -- Operators are `.operator`, including multi-character symbols (classified per character) and
 -- Unicode math symbols like the function arrow.

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -317,4 +317,204 @@ elab "#evalHighlight'" inp:str exp:str : command => do
 
 end
 
+/-! # Token kinds -/
+section TokenKinds
+open SubVerso.Highlighting
+
+namespace SubVerso.Highlighting
+
+/-- The name of a token kind's constructor, for use in assertions (payloads are ignored). -/
+def Token.Kind.name : Token.Kind → String
+  | .keyword .. => "keyword"
+  | .const .. => "const"
+  | .anonCtor .. => "anonCtor"
+  | .var .. => "var"
+  | .str .. => "str"
+  | .option .. => "option"
+  | .docComment => "docComment"
+  | .sort .. => "sort"
+  | .levelVar .. => "levelVar"
+  | .levelOp .. => "levelOp"
+  | .levelConst .. => "levelConst"
+  | .moduleName .. => "moduleName"
+  | .withType .. => "withType"
+  | .num .. => "num"
+  | .char .. => "char"
+  | .lineComment => "lineComment"
+  | .blockComment => "blockComment"
+  | .commentDelim => "commentDelim"
+  | .operator .. => "operator"
+  | .bracket .. => "bracket"
+  | .separator .. => "separator"
+  | .unknown => "unknown"
+
+/-- Collects all tokens of a highlighted tree, in source order. -/
+partial def Highlighted.tokenList (hl : Highlighted) : Array Token := Id.run do
+  let mut out := #[]
+  match hl with
+  | .seq hls => for x in hls do out := out ++ x.tokenList
+  | .span _ hl' => out := hl'.tokenList
+  | .tactics _ _ _ hl' => out := hl'.tokenList
+  | .token t => out := #[t]
+  | _ => pure ()
+  return out
+
+/-- The occurrence tag of a production-bearing token kind, if any. -/
+def Token.Kind.occurrence? : Token.Kind → Option String
+  | .keyword _ occ _ | .operator _ occ _ | .bracket _ occ _ | .separator _ occ _ => occ
+  | _ => none
+
+/-- Whether a token survives a `ToJson`/`FromJson` round-trip unchanged. -/
+def Token.jsonRoundtrips (t : Token) : Bool :=
+  match (Lean.fromJson? (Lean.toJson t) : Except String Token) with
+  | .ok t' => t' == t
+  | .error _ => false
+
+end SubVerso.Highlighting
+
+open Lean Elab Command in
+/--
+`#assertKind inp content kind` highlights `inp` and checks that every token whose content equals
+`content` has the given kind constructor name. Errors if no such token exists.
+-/
+elab "#assertKind" inp:str content:str kind:str : command => do
+  let hl ← highlightFromString inp.getString
+  let toks := hl.tokenList
+  let matching := toks.filter (·.content == content.getString)
+  if matching.isEmpty then
+    let all := toks.toList.map fun t => (t.content, t.kind.name)
+    throwError m!"No token with content {repr content.getString}. Tokens: {repr all}"
+  for t in matching do
+    if t.kind.name != kind.getString then
+      throwError m!"Token {repr t.content} has kind {t.kind.name}, expected {kind.getString}"
+
+open Lean Elab Command in
+/-- `#assertHasKind inp kind` highlights `inp` and checks that at least one token has `kind`. -/
+elab "#assertHasKind" inp:str kind:str : command => do
+  let hl ← highlightFromString inp.getString
+  let toks := hl.tokenList
+  unless toks.any (·.kind.name == kind.getString) do
+    let all := toks.toList.map fun t => (t.content, t.kind.name)
+    throwError m!"No token of kind {kind.getString}. Tokens: {repr all}"
+
+open Lean Elab Command in
+/--
+Checks that the token(s) with `content` carry an occurrence tag that is not attributed to an
+anonymous `null` grouping node (regression guard for null-node transparency).
+-/
+elab "#assertOccurrenceNotNull" inp:str content:str : command => do
+  let hl ← highlightFromString inp.getString
+  let matching := hl.tokenList.filter (·.content == content.getString)
+  if matching.isEmpty then throwError m!"no token with content {repr content.getString}"
+  for t in matching do
+    match t.kind.occurrence? with
+    | some occ =>
+      if occ.startsWith "null" then
+        throwError m!"token {repr t.content} ({t.kind.name}) has a null-based occurrence {repr occ}"
+    | none => throwError m!"token {repr t.content} ({t.kind.name}) has no occurrence"
+
+open Lean Elab Command in
+/-- Checks that `inp` highlights to a `.char` token whose decoded character equals `expected`. -/
+elab "#assertCharValue" inp:str expected:str : command => do
+  let hl ← highlightFromString inp.getString
+  let chars := hl.tokenList.filterMap fun t =>
+    match t.kind with | .char c => some c.toString | _ => none
+  unless chars.contains expected.getString do
+    throwError m!"char tokens decoded to {repr chars.toList}, expected to contain {repr expected.getString}"
+
+open Lean Elab Command in
+/--
+Like `#assertKind`, but highlights through the info-recording (Compat-frontend, includes-unparsed)
+path so that semantic info — e.g. an applied constructor in `⟨1, 2⟩` — is available, mirroring real
+extraction (`subverso-extract-mod`).
+-/
+elab "#assertKindRich" inp:str content:str kind:str : command => do
+  let hl ← highlightWithPrefixedMessages inp.getString
+  let toks := hl.tokenList
+  let matching := toks.filter (·.content == content.getString)
+  if matching.isEmpty then
+    let all := toks.toList.map fun t => (t.content, t.kind.name)
+    throwError m!"No token with content {repr content.getString}. Tokens: {repr all}"
+  for t in matching do
+    if t.kind.name != kind.getString then
+      throwError m!"Token {repr t.content} has kind {t.kind.name}, expected {kind.getString}"
+
+-- Numerals (decimal, hex, scientific) are `.num`
+#assertKind "def n := 42" "42" "num"
+#assertKind "def n := 0xff" "0xff" "num"
+#assertKind "def n := 1.5e3" "1.5e3" "num"
+
+-- Character literals are `.char`, carrying the *decoded* character (escapes resolved)
+#assertKind "def c := 'a'" "'a'" "char"
+#assertCharValue "def c := 'a'" "a"
+#assertCharValue "def c := '\\n'" "\n"
+
+-- Comments are split into delimiter tokens (`--`, `/-`, `-/`) and body text, and the surrounding
+-- source still round-trips byte-for-byte. A trailing line comment lives in trailing trivia; a
+-- block comment in leading trivia of an inner token. Both paths are exercised.
+#assertKind "def x := 1 -- note" "--" "commentDelim"
+#assertKind "def x := 1 -- note" " note" "lineComment"
+#evalHighlight' "def x := 1 -- note" "def x := 1 -- note"
+#assertKind "def y :=\n  /- block -/ 2" "/-" "commentDelim"
+#assertKind "def y :=\n  /- block -/ 2" "-/" "commentDelim"
+#assertKind "def y :=\n  /- block -/ 2" " block " "blockComment"
+#evalHighlight' "def y :=\n  /- block -/ 2" "def y :=\n  /- block -/ 2"
+-- Nested block comments are depth-balanced: only the outermost `/-` / `-/` are delimiter tokens,
+-- and the nested delimiters remain part of the single body text. Round-trips byte-for-byte.
+#assertKind "def z :=\n  /- a /- b -/ c -/ 3" "/-" "commentDelim"
+#assertKind "def z :=\n  /- a /- b -/ c -/ 3" "-/" "commentDelim"
+#assertKind "def z :=\n  /- a /- b -/ c -/ 3" " a /- b -/ c " "blockComment"
+#evalHighlight' "def z :=\n  /- a /- b -/ c -/ 3" "def z :=\n  /- a /- b -/ c -/ 3"
+
+-- Operators are `.operator`, including multi-character symbols (classified per character) and
+-- Unicode math symbols like the function arrow.
+#assertKind "def f (a b : Nat) := a + b" "+" "operator"
+#assertKind "def g (a : Option Nat) (b : Nat → Option Nat) := a >>= b" ">>=" "operator"
+#assertKind "def fn : Nat → Nat := id" "→" "operator"
+-- A subscript/superscript-decorated operator (an operator char plus subscript/superscript chars)
+-- is still an operator, including superscript operator signs like `⁻` in `⁻¹`.
+#assertKind "infixl:65 \" +ₙ \" => Nat.add\ndef z := 1 +ₙ 2" "+ₙ" "operator"
+#assertKind "postfix:max \"⁻¹\" => Nat.succ\ndef w := 0⁻¹" "⁻¹" "operator"
+-- But a letter-like notation symbol that doesn't resolve stays `.unknown` rather than being
+-- mislabeled as an operator (it has no operator character).
+#assertKind "prefix:max \"𝒫\" => Nat.succ\ndef y := 𝒫 0" "𝒫" "unknown"
+
+-- List brackets and separators
+#assertKind "def l := [1, 2]" "[" "bracket"
+#assertKind "def l := [1, 2]" "]" "bracket"
+#assertKind "def l := [1, 2]" "," "separator"
+-- The separator sits inside a `sepBy` null grouping; it must inherit the surrounding list
+-- production rather than the meaningless `null` kind.
+#assertOccurrenceNotNull "def l := [1, 2]" ","
+
+-- Anonymous-constructor delimiters keep `.anonCtor` (carrying the constructor's name/signature),
+-- rather than being reclassified as brackets/separators by the new lexical step. Verified through
+-- the info-recording highlight path, where the applied constructor `Prod.mk 1 2` is resolved.
+#assertKindRich "def p : Nat × Nat := ⟨1, 2⟩" "⟨" "anonCtor"
+#assertKindRich "def p : Nat × Nat := ⟨1, 2⟩" "⟩" "anonCtor"
+#assertKindRich "def p : Nat × Nat := ⟨1, 2⟩" "," "anonCtor"
+
+-- Core symbolic keywords/delimiters stay `.keyword`, not `.operator`
+#assertKind "def x := 1" ":=" "keyword"
+#assertKind "def f := fun x => x" "=>" "keyword"
+
+-- Module docs are tagged like doc comments
+#assertHasKind "/-! module doc -/" "docComment"
+
+-- The derived `ToJson`/`FromJson` instances round-trip every new token kind
+#evalString "true\n"
+  (([Token.Kind.num (some "Nat") none, .num none none, .char 'a', .lineComment, .blockComment,
+     .commentDelim, .operator (some `foo) (some "foo-1") (some "d"), .bracket none none none,
+     .separator none none none] : List Token.Kind).all (fun k => Token.jsonRoundtrips ⟨k, "x"⟩))
+
+-- The new `identKind`-first atom step: a nullary notation atom (`ℕ`) resolves span-exact to its
+-- constant (`.const`), while a genuine infix operator (`+`) has no span-exact info and stays
+-- `.operator`. Both require the info-recording highlight path (`#assertKindRich`), as in real
+-- extraction; this needs no Mathlib — a local `notation` suffices.
+#assertKindRich "notation \"ℕ\" => Nat\ndef m : ℕ := 0" "ℕ" "const"
+#assertKindRich "def f (a b : Nat) := a + b" "+" "operator"
+#assertKind "def x := 1" ":=" "keyword"
+
+end TokenKinds
+
 def main : IO Unit := pure ()

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -359,6 +359,13 @@ partial def Highlighted.tokenList (hl : Highlighted) : Array Token := Id.run do
   | _ => pure ()
   return out
 
+/-- Whether the highlighted tree contains a `.tactics` (proof-state) wrapper. -/
+partial def Highlighted.hasTactics : Highlighted → Bool
+  | .tactics .. => true
+  | .seq hls => hls.any Highlighted.hasTactics
+  | .span _ hl => hl.hasTactics
+  | _ => false
+
 /-- The occurrence tag of a production-bearing token kind, if any. -/
 def Token.Kind.occurrence? : Token.Kind → Option String
   | .keyword _ occ _ | .operator _ occ _ | .bracket _ occ _ | .separator _ occ _ => occ
@@ -400,8 +407,9 @@ elab "#assertHasKind" inp:str kind:str : command => do
 open Lean Elab Command in
 /--
 `#assertAnchor inp name expected` highlights `inp` (so comments are tokenized), runs the anchor
-extractor, and checks that the anchor `name` exists and its trimmed code equals `expected`. This
-guards that `-- ANCHOR:`/`-- ANCHOR_END:` directives are still recognized after comment tokenization.
+extractor, and checks that the anchor `name` exists and its code equals `expected` exactly
+(untrimmed — the surrounding whitespace is part of what these tests protect). This guards that
+`-- ANCHOR:`/`-- ANCHOR_END:` directives are still recognized after comment tokenization.
 -/
 elab "#assertAnchor" inp:str name:str expected:str : command => do
   let hl ← highlightFromString inp.getString
@@ -616,6 +624,9 @@ open Lean Elab Command in
     | some a =>
       unless (a.toString.splitOn "trivial").length > 1 do
         throwError m!"anchor 'pf' lost its tactic content: {repr a.toString}"
+      -- The `.tactics` wrapper must survive extraction, not just the text content.
+      unless a.hasTactics do
+        throwError m!"anchor 'pf' lost its tactic-state wrapper: {repr a}"
 
 -- Exact newline/indentation behavior: a directive at end-of-input (no trailing newline), blank lines
 -- around a directive, and a tab-indented directive (tabs count as line-leading whitespace).

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -346,9 +346,11 @@ namespace SubVerso.Highlighting
 /-- The name of a token kind's constructor, for use in assertions (payloads are ignored). -/
 def Token.Kind.name : Token.Kind → String
   | .keyword .. => "keyword"
+  | .delim .. => "delim"
   | .const .. => "const"
   | .anonCtor .. => "anonCtor"
   | .var .. => "var"
+  | .wildcard .. => "wildcard"
   | .str .. => "str"
   | .option .. => "option"
   | .docComment => "docComment"
@@ -388,7 +390,7 @@ partial def Highlighted.hasTactics : Highlighted → Bool
 
 /-- The occurrence tag of a production-bearing token kind, if any. -/
 def Token.Kind.occurrence? : Token.Kind → Option String
-  | .keyword _ occ _ | .operator _ occ _ | .bracket _ occ _ | .separator _ occ _ => occ
+  | .keyword _ occ _ | .delim _ occ _ | .operator _ occ _ | .bracket _ occ _ | .separator _ occ _ => occ
   | _ => none
 
 /-- Whether a token survives a `ToJson`/`FromJson` round-trip unchanged. -/
@@ -484,6 +486,19 @@ elab "#assertNumType" inp:str content:str expectedType:str : command => do
         throwError m!"numeral {repr content.getString} has type {repr ty}, expected {repr expectedType.getString}"
     | .num none _ => throwError m!"numeral {repr content.getString} has no inferred type"
     | _ => throwError m!"token {repr content.getString} is not a numeral"
+
+open Lean Elab Command in
+/-- Checks that the wildcard `_` with `content` is a `.wildcard` carrying the inferred `expectedType`. -/
+elab "#assertWildcardType" inp:str content:str expectedType:str : command => do
+  let hl ← highlightWithPrefixedMessages inp.getString
+  let toks := hl.tokenList.filter (·.content == content.getString)
+  if toks.isEmpty then throwError m!"no token with content {repr content.getString}"
+  for t in toks do
+    match t.kind with
+    | .wildcard ty _ =>
+      if ty != expectedType.getString then
+        throwError m!"wildcard {repr content.getString} has type {repr ty}, expected {repr expectedType.getString}"
+    | _ => throwError m!"token {repr content.getString} is not a wildcard (is {t.kind.name})"
 
 open Lean Elab Command in
 /-- Highlights `inp` with tactic info and checks the anchor pass found a proof state named `name`. -/
@@ -706,9 +721,16 @@ open Lean Elab Command in
 #assertKindRich "def p : Nat × Nat := ⟨1, 2⟩" "⟩" "anonCtor"
 #assertKindRich "def p : Nat × Nat := ⟨1, 2⟩" "," "anonCtor"
 
--- Core symbolic keywords/delimiters stay `.keyword`, not `.operator`
-#assertKind "def x := 1" ":=" "keyword"
-#assertKind "def f := fun (x : Nat) => x" "=>" "keyword"
+-- Core symbolic delimiters (`:=`, `=>`, …) are `.delim`, not `.operator` and not the bold `.keyword`
+#assertKind "def x := 1" ":=" "delim"
+#assertKind "def f := fun (x : Nat) => x" "=>" "delim"
+
+-- A wildcard / hole `_` is its own kind, not a `.var` (so it isn't italicized like a variable)
+#assertKind "def f := fun _ => 0" "_" "wildcard"
+#assertKindRich "def f := fun _ => 0" "_" "wildcard"
+#assertKindRich "def f (n : Nat) := match n with\n  | _ => 0" "_" "wildcard"
+-- Like `var`, a wildcard keeps the inferred type of its binder for hover.
+#assertWildcardType "def f := fun (_ : Nat) => 0" "_" "Nat"
 
 -- Module docs are tagged like doc comments
 #assertHasKind "/-! module doc -/" "docComment"
@@ -717,7 +739,9 @@ open Lean Elab Command in
 #evalString "true\n"
   (([Token.Kind.num (some "Nat") none, .num none none, .char 'a', .lineComment, .blockComment,
      .commentDelim, .operator (some `foo) (some "foo-1") (some "d"), .bracket none none none,
-     .separator none none none] : List Token.Kind).all (fun k => Token.jsonRoundtrips ⟨k, "x"⟩))
+     .separator none none none, .delim (some `foo) (some "foo-1") (some "d"),
+     .wildcard "Nat" none, .wildcard "" (some "[]")]
+     : List Token.Kind).all (fun k => Token.jsonRoundtrips ⟨k, "x"⟩))
 
 -- The new `identKind`-first atom step: a nullary notation atom (`ℕ`) resolves span-exact to its
 -- constant (`.const`), while a genuine infix operator (`+`) has no span-exact info and stays
@@ -725,7 +749,13 @@ open Lean Elab Command in
 -- extraction; this needs no Mathlib — a local `notation` suffices.
 #assertKindRich "notation \"ℕ\" => Nat\ndef m : ℕ := 0" "ℕ" "const"
 #assertKindRich "def f (a b : Nat) := a + b" "+" "operator"
-#assertKind "def x := 1" ":=" "keyword"
+
+-- `:=` stays a `.delim` across contexts even on the info-recording path, where `identKind` could
+-- otherwise match its span: a structure-instance field, an `instance … where` field, and a tactic
+-- `have` all keep it a delim (it is peeled off before `identKind` is consulted).
+#assertKindRich "structure S where\n  x : Nat\n#check ({ x := 1 } : S)" ":=" "delim"
+#assertKindRich "class C (a : Type) where\n  f : a → a\ninstance : C Nat where\n  f x := x" ":=" "delim"
+#assertKindRich "theorem t : True := by\n  have h : True := trivial\n  exact h" ":=" "delim"
 
 end TokenKinds
 

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -431,6 +431,54 @@ elab "#assertAnchorKeepsComment" inp:str content:str : command => do
 
 open Lean Elab Command in
 /--
+Like `#assertAnchorKeepsComment`, but checks `ex.code` for a token of an arbitrary `kind` (e.g.
+`blockComment`, `docComment`) with `content`. The anchored extractor must leave such comments
+untouched.
+-/
+elab "#assertAnchorCodeHasToken" inp:str kind:str content:str : command => do
+  let hl ← highlightFromString inp.getString
+  match hl.anchored with
+  | .error e => throwError m!"anchored failed: {e}"
+  | .ok ex =>
+    unless ex.code.tokenList.any (fun t => t.kind.name == kind.getString && t.content == content.getString) do
+      throwError m!"anchored code lost the {kind.getString} token {repr content.getString}"
+
+open Lean Elab Command in
+/-- Checks that the numeral with `content` carries the inferred type `expectedType`. -/
+elab "#assertNumType" inp:str content:str expectedType:str : command => do
+  let hl ← highlightWithPrefixedMessages inp.getString
+  let toks := hl.tokenList.filter (·.content == content.getString)
+  if toks.isEmpty then throwError m!"no token with content {repr content.getString}"
+  for t in toks do
+    match t.kind with
+    | .num (some ty) _ =>
+      if ty != expectedType.getString then
+        throwError m!"numeral {repr content.getString} has type {repr ty}, expected {repr expectedType.getString}"
+    | .num none _ => throwError m!"numeral {repr content.getString} has no inferred type"
+    | _ => throwError m!"token {repr content.getString} is not a numeral"
+
+open Lean Elab Command in
+/-- Highlights `inp` with tactic info and checks the anchor pass found a proof state named `name`. -/
+elab "#assertProofState" inp:str name:str : command => do
+  let hl ← highlightWithPrefixedMessages inp.getString
+  match hl.anchored with
+  | .error e => throwError m!"anchored failed: {e}"
+  | .ok ex =>
+    unless (Compat.HashMap.get? ex.proofStates name.getString).isSome do
+      throwError m!"no proof state named {repr name.getString}"
+
+open Lean Elab Command in
+/-- Checks that `anchored` on the highlighting of `inp` fails with a message starting with `expected`. -/
+elab "#assertAnchorError" inp:str expected:str : command => do
+  let hl ← highlightFromString inp.getString
+  match hl.anchored with
+  | .ok _ => throwError m!"expected anchored to fail ({repr expected.getString}), but it succeeded"
+  | .error e =>
+    unless expected.getString.isPrefixOf e do
+      throwError m!"anchored error {repr e} does not start with {repr expected.getString}"
+
+open Lean Elab Command in
+/--
 Checks that the token(s) with `content` carry an occurrence tag that is not attributed to an
 anonymous `null` grouping node (regression guard for null-node transparency).
 -/
@@ -475,6 +523,9 @@ elab "#assertKindRich" inp:str content:str kind:str : command => do
 #assertKind "def n := 42" "42" "num"
 #assertKind "def n := 0xff" "0xff" "num"
 #assertKind "def n := 1.5e3" "1.5e3" "num"
+-- A numeral carries its inferred type (read from its own info), including non-trivial types.
+#assertNumType "def n := 42" "42" "Nat"
+#assertNumType "def n : Fin 5 := 3" "3" "Fin 5"
 
 -- Character literals are `.char`, carrying the *decoded* character (escapes resolved)
 #assertKind "def c := 'a'" "'a'" "char"
@@ -509,6 +560,70 @@ elab "#assertKindRich" inp:str content:str kind:str : command => do
 -- begin with `--`), so it stays a highlighted comment token rather than being flattened to text.
 #assertAnchorKeepsComment "def x := 1 -- ANCHOR: note" " ANCHOR: note"
 
+-- Proof-state directives are recognized after comment tokenization (the `commentDelim`/`lineComment`
+-- retexting path), with the `^` column resolved against the tactic line above.
+#assertProofState "example : True := by\n  trivial\n--^ PROOF_STATE: st" "st"
+
+-- Comments that look like directives but are not directive *lines* must keep their token styling:
+-- a block comment and an ordinary full-line comment, both containing `ANCHOR:`.
+#assertAnchorCodeHasToken "def x := 1\n/- ANCHOR: foo -/\ndef y := 2" "blockComment" " ANCHOR: foo "
+#assertAnchorKeepsComment "def x := 1\n-- not ANCHOR: foo\ndef y := 2" " not ANCHOR: foo"
+
+-- Disabling a flag leaves the corresponding directive comments untouched in the extracted code.
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  let hl ← highlightFromString "def a := 0\n-- ANCHOR: foo\ndef x := 1\n-- ANCHOR_END: foo"
+  match hl.anchored (textAnchors := false) with
+  | .error e => throwError m!"unexpected error with textAnchors := false: {e}"
+  | .ok ex =>
+    unless ex.code.tokenList.any (fun t => t.kind.name == "lineComment" && t.content == " ANCHOR: foo") do
+      throwError "ANCHOR comment was not preserved with textAnchors := false"
+    unless ex.anchors.isEmpty do throwError "anchors found despite textAnchors := false"
+
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  let hl ← highlightWithPrefixedMessages "example : True := by\n  trivial\n--^ PROOF_STATE: st"
+  match hl.anchored (proofStates := false) with
+  | .error e => throwError m!"unexpected error with proofStates := false: {e}"
+  | .ok ex =>
+    unless ex.code.tokenList.any (fun t => t.kind.name == "lineComment" && t.content == "^ PROOF_STATE: st") do
+      throwError "PROOF_STATE comment was not preserved with proofStates := false"
+
+-- Error cases still fire after comment tokenization.
+#assertAnchorError "def x := 1\n-- ANCHOR_END: foo\ndef y := 2" "Anchor not open"
+#assertAnchorError "def a := 0\n-- ANCHOR: foo\ndef x := 1\n-- ANCHOR: foo\ndef y := 2" "Anchor already opened"
+#assertAnchorError "def a := 0\n-- ANCHOR: foo\ndef x := 1" "Unclosed anchors"
+
+-- Duplicate proof-state name (needs tactic info, so via the info-recording harness).
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  let hl ← highlightWithPrefixedMessages "example : True := by\n  trivial\n--^ PROOF_STATE: st\n--^ PROOF_STATE: st"
+  match hl.anchored with
+  | .ok _ => throwError "expected a duplicate proof-state error"
+  | .error e =>
+    unless "Proof state already found".isPrefixOf e do throwError m!"unexpected error: {e}"
+
+-- A directive comment inside a tactic block is extracted with its surrounding tactic context
+-- (exercises the `ctx` threading in `anchored`).
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  let hl ← highlightWithPrefixedMessages "example : True := by\n  -- ANCHOR: pf\n  trivial\n  -- ANCHOR_END: pf"
+  match hl.anchored with
+  | .error e => throwError m!"anchored failed: {e}"
+  | .ok ex =>
+    match Compat.HashMap.get? ex.anchors "pf" with
+    | none => throwError "no anchor 'pf'"
+    | some a =>
+      unless (a.toString.splitOn "trivial").length > 1 do
+        throwError m!"anchor 'pf' lost its tactic content: {repr a.toString}"
+
+-- Exact newline/indentation behavior: a directive at end-of-input (no trailing newline), blank lines
+-- around a directive, and a tab-indented directive (tabs count as line-leading whitespace).
+#assertAnchor "def a := 0\n-- ANCHOR: foo\ndef x := 1\n-- ANCHOR_END: foo" "foo" "def x := 1\n"
+#assertAnchor "def a := 0\n\n-- ANCHOR: foo\n\ndef x := 1\n-- ANCHOR_END: foo" "foo" "\ndef x := 1\n"
+-- A more deeply indented directive (extra leading spaces) is still recognized as a line start.
+#assertAnchor "def a := 0\nsection\n    -- ANCHOR: foo\n    def x := 1\n    -- ANCHOR_END: foo\nend" "foo" "    def x := 1\n"
+
 -- Operators are `.operator`, including multi-character symbols (classified per character) and
 -- Unicode math symbols like the function arrow.
 #assertKind "def f (a b : Nat) := a + b" "+" "operator"
@@ -517,7 +632,9 @@ elab "#assertKindRich" inp:str content:str kind:str : command => do
 -- A subscript/superscript-decorated operator (an operator char plus subscript/superscript chars)
 -- is still an operator, including superscript operator signs like `⁻` in `⁻¹`.
 #assertKind "infixl:65 \" +ₙ \" => Nat.add\ndef z := 1 +ₙ 2" "+ₙ" "operator"
-#assertKind "postfix:max \"⁻¹\" => Nat.succ\ndef w := 0⁻¹" "⁻¹" "operator"
+-- A superscript-minus operator char plus a superscript digit classifies as an operator. Uses the
+-- obscure `⁻²` token rather than `⁻¹`, which would clash with the built-in `Inv.inv` notation.
+#assertKind "postfix:max \"⁻²\" => Nat.succ\ndef w := 0⁻²" "⁻²" "operator"
 -- But a letter-like notation symbol that doesn't resolve stays `.unknown` rather than being
 -- mislabeled as an operator (it has no operator character).
 #assertKind "prefix:max \"𝒫\" => Nat.succ\ndef y := 𝒫 0" "𝒫" "unknown"
@@ -539,7 +656,7 @@ elab "#assertKindRich" inp:str content:str kind:str : command => do
 
 -- Core symbolic keywords/delimiters stay `.keyword`, not `.operator`
 #assertKind "def x := 1" ":=" "keyword"
-#assertKind "def f := fun x => x" "=>" "keyword"
+#assertKind "def f := fun (x : Nat) => x" "=>" "keyword"
 
 -- Module docs are tagged like doc comments
 #assertHasKind "/-! module doc -/" "docComment"

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -686,6 +686,15 @@ open Lean Elab Command in
 #assertKind "def l := [1, 2]" "[" "bracket"
 #assertKind "def l := [1, 2]" "]" "bracket"
 #assertKind "def l := [1, 2]" "," "separator"
+-- The array-literal opener `#[` is a single token combining `#` with `[`; it is a bracket too.
+#assertKind "def arr := #[1, 2]" "#[" "bracket"
+#assertKind "def arr := #[1, 2]" "]" "bracket"
+-- A letter-prefixed bracket notation (`foo[ … ]`) is bracket-like, not a keyword.
+#assertKind "notation:max \"foo[\" n \"]\" => n\ndef z := foo[5]" "foo[" "bracket"
+-- A mathematical-script-letter prefix (`ℰ⟦ … ⟧`) counts as a letter, so this is a bracket too.
+#assertKind "notation:max \"ℰ⟦\" n \"⟧\" => n\ndef z := ℰ⟦5⟧" "ℰ⟦" "bracket"
+#assertKind "notation \"{!\" n \"!}\" => n\ndef w := {! 5 !}" "{!" "bracket"
+#assertKind "notation \"{!\" n \"!}\" => n\ndef w := {! 5 !}" "!}" "bracket"
 -- The separator sits inside a `sepBy` null grouping; it must inherit the surrounding list
 -- production rather than the meaningless `null` kind.
 #assertOccurrenceNotNull "def l := [1, 2]" ","

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -411,9 +411,9 @@ elab "#assertAnchor" inp:str name:str expected:str : command => do
     match Compat.HashMap.get? ex.anchors name.getString with
     | none => throwError m!"No anchor named {repr name.getString}"
     | some a =>
-      let got := Compat.String.trim a.toString
-      if got != expected.getString then
-        throwError m!"Anchor {repr name.getString} = {repr got}, expected {repr expected.getString}"
+      -- Compare the exact (untrimmed) anchor code, so a stray leading/trailing newline is caught.
+      if a.toString != expected.getString then
+        throwError m!"Anchor {repr name.getString} = {repr a.toString}, expected {repr expected.getString}"
 
 open Lean Elab Command in
 /--
@@ -484,11 +484,13 @@ elab "#assertKindRich" inp:str content:str kind:str : command => do
 #assertKind "def z :=\n  /- a /- b -/ c -/ 3" " a /- b -/ c " "blockComment"
 #evalHighlight' "def z :=\n  /- a /- b -/ c -/ 3" "def z :=\n  /- a /- b -/ c -/ 3"
 
--- `-- ANCHOR:` / `-- ANCHOR_END:` directives are still recognized after comment tokenization: the
--- anchor scanner reconstructs the comment line from its tokens.
-#assertAnchor "def pre := 0\n-- ANCHOR: foo\ndef x := 1\n-- ANCHOR_END: foo\ndef post := 2" "foo" "def x := 1"
--- Indented directive comments are recognized too.
-#assertAnchor "def pre := 0\nsection\n  -- ANCHOR: bar\n  def x := 1\n  -- ANCHOR_END: bar\nend" "bar" "def x := 1"
+-- `-- ANCHOR:` / `-- ANCHOR_END:` directives are still recognized after comment tokenization, and
+-- the whole directive line (with its newline) is consumed — no extra blank lines, and the anchor
+-- has no stray leading/trailing newline (checked untrimmed).
+#assertAnchor "def pre := 0\n-- ANCHOR: foo\ndef x := 1\n-- ANCHOR_END: foo\ndef post := 2" "foo" "def x := 1\n"
+-- Indented directive comments are recognized too, and their indentation is consumed with the line;
+-- the kept code retains its own indentation.
+#assertAnchor "def pre := 0\nsection\n  -- ANCHOR: bar\n  def x := 1\n  -- ANCHOR_END: bar\nend" "bar" "  def x := 1\n"
 
 -- Operators are `.operator`, including multi-character symbols (classified per character) and
 -- Unicode math symbols like the function arrow.

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -724,6 +724,15 @@ open Lean Elab Command in
 -- Core symbolic delimiters (`:=`, `=>`, …) are `.delim`, not `.operator` and not the bold `.keyword`
 #assertKind "def x := 1" ":=" "delim"
 #assertKind "def f := fun (x : Nat) => x" "=>" "delim"
+-- A run of only `.` is a delimiter (e.g. the projection dot).
+#assertKindRich "def n : Nat := (0 : Nat).succ" "." "delim"
+-- A `·` proof-focus bullet has no term info, so it is a delimiter; an anonymous-function
+-- placeholder `(· + 1)` resolves to a variable and keeps that kind.
+#assertKindRich "example : True ∧ True := by\n  refine ⟨?_, ?_⟩\n  · trivial\n  · trivial" "·" "delim"
+#assertKindRich "def f : Nat → Nat := (· + 1)" "·" "var"
+-- An anonymous `instance` keyword resolves span-exact to the synthesized instance name, but must
+-- stay a keyword rather than being rendered as that constant.
+#assertKindRich "class Foo (α : Type) where\n  bar : α\ninstance : Foo Nat where\n  bar := 0" "instance" "keyword"
 
 -- A wildcard / hole `_` is its own kind, not a `.var` (so it isn't italicized like a variable)
 #assertKind "def f := fun _ => 0" "_" "wildcard"

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -735,8 +735,8 @@ open Lean Elab Command in
 #assertKindRich "class Foo (α : Type) where\n  bar : α\ninstance : Foo Nat where\n  bar := 0" "instance" "keyword"
 
 -- A wildcard / hole `_` is its own kind, not a `.var` (so it isn't italicized like a variable)
-#assertKind "def f := fun _ => 0" "_" "wildcard"
-#assertKindRich "def f := fun _ => 0" "_" "wildcard"
+#assertKind "def f := fun (_ : Nat) => 0" "_" "wildcard"
+#assertKindRich "def f := fun (_ : String) => 0" "_" "wildcard"
 #assertKindRich "def f (n : Nat) := match n with\n  | _ => 0" "_" "wildcard"
 -- Like `var`, a wildcard keeps the inferred type of its binder for hover.
 #assertWildcardType "def f := fun (_ : Nat) => 0" "_" "Nat"

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -417,6 +417,20 @@ elab "#assertAnchor" inp:str name:str expected:str : command => do
 
 open Lean Elab Command in
 /--
+Checks that, after the anchor pass, `ex.code` still contains a `.lineComment` token with `content`.
+Guards that a comment which merely *looks* like a directive (e.g. trailing one) keeps its token
+styling rather than being flattened to text.
+-/
+elab "#assertAnchorKeepsComment" inp:str content:str : command => do
+  let hl ← highlightFromString inp.getString
+  match hl.anchored with
+  | .error e => throwError m!"anchored failed: {e}"
+  | .ok ex =>
+    unless ex.code.tokenList.any (fun t => t.kind.name == "lineComment" && t.content == content.getString) do
+      throwError m!"anchored code lost the lineComment token {repr content.getString}"
+
+open Lean Elab Command in
+/--
 Checks that the token(s) with `content` carry an occurrence tag that is not attributed to an
 anonymous `null` grouping node (regression guard for null-node transparency).
 -/
@@ -491,6 +505,9 @@ elab "#assertKindRich" inp:str content:str kind:str : command => do
 -- Indented directive comments are recognized too, and their indentation is consumed with the line;
 -- the kept code retains its own indentation.
 #assertAnchor "def pre := 0\nsection\n  -- ANCHOR: bar\n  def x := 1\n  -- ANCHOR_END: bar\nend" "bar" "  def x := 1\n"
+-- A trailing comment that merely looks like a directive is NOT a directive line (the line doesn't
+-- begin with `--`), so it stays a highlighted comment token rather than being flattened to text.
+#assertAnchorKeepsComment "def x := 1 -- ANCHOR: note" " ANCHOR: note"
 
 -- Operators are `.operator`, including multi-character symbols (classified per character) and
 -- Unicode math symbols like the function arrow.

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -298,6 +298,26 @@ def highlightFromString (input : String) : CommandElabM Highlighting.Highlighted
     hls := hls ++ hl
   return hls
 
+open Lean Elab Command in
+/--
+Highlights `input` via the module path (`highlightFrontendResult` with `pp.tagAppFns` set), the way
+`subverso-extract-mod` does. This produces the tactic-region structure that per-command highlighting
+doesn't, so it exercises comment trivia inside proof tactics.
+-/
+def highlightModuleStyle (input : String) : CommandElabM Highlighting.Highlighted := do
+  let inputCtx := Parser.mkInputContext input "<input>"
+  let commandState : Command.State := { env := (← getEnv), maxRecDepth := (← get).maxRecDepth }
+  let commandState :=
+    let sc := commandState.scopes[0]!
+    { commandState with scopes := { sc with opts := sc.opts.setBool `pp.tagAppFns true } :: commandState.scopes.tail! }
+  let (result, _) ← Compat.Frontend.processCommands mkNullNode
+    |>.run { inputCtx } |>.run { commandState, parserState := {}, cmdPos := 0 }
+  let result := result.updateLeading input
+  runTermElabM fun _ =>
+    withTheReader Core.Context (fun ctx => { ctx with fileMap := inputCtx.fileMap }) do
+      let hls ← Highlighting.highlightFrontendResult result
+      return hls.foldl (· ++ ·) .empty
+
 /--
 `#evalHighlight inp exp` highlights `inp` using the including-unparsed
 highlighter and checks that the result matches `exp`, where only messages
@@ -571,6 +591,18 @@ elab "#assertKindRich" inp:str content:str kind:str : command => do
 -- Proof-state directives are recognized after comment tokenization (the `commentDelim`/`lineComment`
 -- retexting path), with the `^` column resolved against the tactic line above.
 #assertProofState "example : True := by\n  trivial\n--^ PROOF_STATE: st" "st"
+-- An *indented* proof-state directive inside a tactic block: its indentation must stay attached to
+-- the comment (the comment token must not be pulled into the tactic region away from its
+-- whitespace), so the `^` column is computed correctly. Checked through the module path (the way
+-- `demo-toml/Anchors.lean` is highlighted), which is where this separation actually occurs.
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  let hl ← highlightModuleStyle "theorem t : ∀ (n : Nat), n = n := by\n  intro n\n  --^ PROOF_STATE: afterIntro\n  rfl"
+  match hl.anchored with
+  | .error e => throwError m!"module-style proof-state extraction failed: {e}"
+  | .ok ex =>
+    unless (Compat.HashMap.get? ex.proofStates "afterIntro").isSome do
+      throwError "no proof state 'afterIntro' (module-style highlighting)"
 
 -- Comments that look like directives but are not directive *lines* must keep their token styling:
 -- a block comment and an ordinary full-line comment, both containing `ANCHOR:`.

--- a/src/SubVerso/Compat.lean
+++ b/src/SubVerso/Compat.lean
@@ -411,7 +411,9 @@ open Lean Elab Command in
   if ← needed (← `(Hashable Char)) then
     elabCommand (← `(instance : Hashable Char where hash c := hash c.val))
   if ← needed (← `(Quote Char)) then
-    elabCommand (← `(instance : Quote Char where quote c := ⟨Syntax.mkCharLit c⟩))
+    -- `Syntax.mkCharLit` doesn't exist on the oldest Leans, so quote as `Char.ofNat <code>`, which
+    -- elaborates back to the character. (Used only to quote highlighted code into terms.)
+    elabCommand (← `(instance : Quote Char where quote c := Syntax.mkCApp ``Char.ofNat #[quote c.toNat]))
 
 abbrev String.take : String → Nat → String :=
   %first_succeeding -warning [

--- a/src/SubVerso/Compat.lean
+++ b/src/SubVerso/Compat.lean
@@ -389,6 +389,30 @@ abbrev String.trimRight : String → String := %first_succeeding -warning [
   @_root_.String.trimRight
 ]
 
+-- `Token.Kind` carries a decoded `Char` for character literals, so its derived
+-- `ToJson`/`FromJson`/`Hashable` and its `Quote` instance need the corresponding `Char` instances.
+-- Core's coverage of these varies across Lean versions (older Leans lack `Hashable Char` and a
+-- term-kind `Quote Char`; no supported version ships `ToJson`/`FromJson Char`), so provide each only
+-- when it can't already be synthesized, never duplicating an instance on a Lean that has it.
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  let needed (cls : TSyntax `term) : CommandElabM Bool := liftTermElabM do
+    match ← Meta.trySynthInstance (← Term.elabTerm cls none) with
+    | .some _ => pure false
+    | _ => pure true
+  if ← needed (← `(ToJson Char)) then
+    elabCommand (← `(instance : ToJson Char where toJson c := toJson c.toString))
+  if ← needed (← `(FromJson Char)) then
+    elabCommand (← `(instance : FromJson Char where
+      fromJson? j := do
+        let s ← fromJson? (α := String) j
+        if s.length = 1 then return String.Pos.get s 0
+        else .error "expected a single-character string for Char"))
+  if ← needed (← `(Hashable Char)) then
+    elabCommand (← `(instance : Hashable Char where hash c := hash c.val))
+  if ← needed (← `(Quote Char)) then
+    elabCommand (← `(instance : Quote Char where quote c := ⟨Syntax.mkCharLit c⟩))
+
 abbrev String.take : String → Nat → String :=
   %first_succeeding -warning [
     fun s n => (_root_.String.take s n).copy,

--- a/src/SubVerso/Highlighting/Anchors/Basic.lean
+++ b/src/SubVerso/Highlighting/Anchors/Basic.lean
@@ -291,6 +291,33 @@ structure AnchoredExamples where
   proofStates : HashMap String Highlighted
 
 /--
+If `line` is an `ANCHOR:`/`ANCHOR_END:`/`PROOF_STATE:` directive, applies it and returns the updated
+anchor and proof-state maps; if it is not a directive, returns `none` (the caller keeps the content).
+`preText` is the document the proof-state caret refers into (its last line is the one pointed at).
+-/
+private def applyDirective
+    (line : String) (preText : Hl) (ctx : Array HlCtx) (textAnchors proofStates : Bool)
+    (openAnchors : HashMap String Hl) (anchorOut tacOut : HashMap String Highlighted) :
+    Except String (Option (HashMap String Hl × HashMap String Highlighted × HashMap String Highlighted)) := do
+  match guard textAnchors *> (anchor? line |>.toOption) with
+  | none =>
+    match guard proofStates *> (proofState? line |>.toOption) with
+    | none => return none
+    | some (p, c) =>
+      let some t := preText.tacticsAt? c
+        | throw s!"No proof state at column {c} for '{p}'"
+      if tacOut.get? p |>.isSome then throw s!"Proof state already found: '{p}'"
+      return some (openAnchors, anchorOut, tacOut.insert p t)
+  | some (a, true) =>
+    if openAnchors.contains a then throw s!"Anchor already opened: {a}"
+    if anchorOut.contains a then throw s!"Anchor already used: {a}"
+    return some (openAnchors.insert a { here := .empty, context := ctx.map (.empty, ·) }, anchorOut, tacOut)
+  | some (a, false) =>
+    let some hl := openAnchors.get? a
+      | throw s!"Anchor not open: {a}"
+    return some (openAnchors.erase a, anchorOut.insert a hl.toHighlighted, tacOut)
+
+/--
 Extracts code from rendered examples based on comment directives.
 
 There are two kinds of extracted code: anchors and named proof states. Anchors name one or more
@@ -326,6 +353,16 @@ def anchored (hl : Highlighted) (textAnchors := true) (proofStates := true) : Ex
   let mut doc : Hl := .empty
   let mut todo := [some (normHl hl)]
   let mut ctx : Array HlCtx := #[]
+  -- State for reconstructing directives from comment tokens (`-- ANCHOR: …`, `-- PROOF_STATE: …`),
+  -- which are now tokenized as `commentDelim`/`lineComment` rather than appearing as plain `.text`:
+  --  * `docBeforeLine` is a snapshot of `doc` taken at the start of the most recent `.text` node. A
+  --    directive comment is always preceded by the whitespace run holding the newline that ends the
+  --    previous line, so when a comment is reached this is `doc` through the end of that previous
+  --    line: its last line is the one a `PROOF_STATE` caret refers to, which `tacticsAt?` searches.
+  --  * `curLineText` is the current line's text so far (after the last newline) — i.e. the comment's
+  --    indentation — used to rebuild the full comment line so proof-state columns stay absolute.
+  let mut docBeforeLine : Hl := .empty
+  let mut curLineText : String := ""
   repeat
     match todo with
     | [] => break
@@ -339,33 +376,37 @@ def anchored (hl : Highlighted) (textAnchors := true) (proofStates := true) : Ex
       -- of comments, in case proof state indicator comments are mixed up with other kinds of
       -- comments.
       let preText := doc
+      -- Snapshot `doc` before this text node for a following comment-token directive: when the next
+      -- node is a directive comment, this text node is the whitespace run starting with the newline
+      -- that ends the previous line, so `docBeforeLine` then holds `doc` through that previous line.
+      docBeforeLine := doc
       todo := hs
       let lines := Internal.getLines s
       for line in lines do
-        match guard textAnchors *> (anchor? line |>.toOption) with
+        match ← applyDirective line preText ctx textAnchors proofStates openAnchors anchorOut tacOut with
         | none =>
-          match guard proofStates *> (proofState? line |>.toOption) with
-          | none =>
-            openAnchors := openAnchors.map fun _ hl => hl ++ line
-            doc := doc ++ line
-          | some (p, c) =>
-            if let some t := preText.tacticsAt? c then
-              if tacOut.get? p |>.isSome then throw s!"Proof state already found: '{p}'"
-              tacOut := tacOut.insert p t
-            else
-              throw s!"No proof state at column {c} for '{p}'"
-        | some (a, true) =>
-          if openAnchors.contains a then throw s!"Anchor already opened: {a}"
-          if anchorOut.contains a then throw s!"Anchor already used: {a}"
-          openAnchors := openAnchors.insert a {
-            here := .empty
-            context := ctx.map (.empty, ·)
-          }
-        | some (a, false) =>
-          if let some hl := openAnchors.get? a then
-            anchorOut := anchorOut.insert a hl.toHighlighted
-            openAnchors := openAnchors.erase a
-          else throw s!"Anchor not open: {a}"
+          openAnchors := openAnchors.map fun _ hl => hl ++ line
+          doc := doc ++ line
+        | some (oa, ao, to) => openAnchors := oa; anchorOut := ao; tacOut := to
+      -- Track the current source line's trailing text (the part after the last newline) so that a
+      -- following comment-token directive can be reconstructed with its original indentation.
+      if lines.size > 1 then curLineText := Compat.Array.back! lines
+      else curLineText := curLineText ++ s
+    | some (.token ⟨.commentDelim, delim⟩) :: some (.token ⟨.lineComment, body⟩) :: hs =>
+      -- A line comment is tokenized as a `--` delimiter plus its body. Reconstruct the original
+      -- comment line (with this line's indentation) so `-- ANCHOR: …` / `-- PROOF_STATE: …`
+      -- directives are still recognized. Non-directive comments are kept as highlighted tokens.
+      -- `docBeforeLine` ends at the previous line, so its last line is the one a `^` would point at.
+      let line := curLineText ++ delim ++ body
+      todo := hs
+      match ← applyDirective line docBeforeLine ctx textAnchors proofStates openAnchors anchorOut tacOut with
+      | none =>
+        let cd : Highlighted := .token ⟨.commentDelim, delim⟩
+        let lc : Highlighted := .token ⟨.lineComment, body⟩
+        openAnchors := openAnchors.map fun _ hl => hl ++ cd ++ lc
+        doc := doc ++ cd ++ lc
+        curLineText := curLineText ++ delim ++ body
+      | some (oa, ao, to) => openAnchors := oa; anchorOut := ao; tacOut := to
     | some h@(.token ..) :: hs | some h@(.point ..) :: hs | some h@(.unparsed ..) :: hs =>
       todo := hs
       openAnchors := openAnchors.map fun _ hl => hl ++ h

--- a/src/SubVerso/Highlighting/Anchors/Basic.lean
+++ b/src/SubVerso/Highlighting/Anchors/Basic.lean
@@ -290,6 +290,12 @@ structure AnchoredExamples where
   -/
   proofStates : HashMap String Highlighted
 
+/-- The anchor/proof-state state updated by applying a directive (see `applyDirective`). -/
+private structure DirectiveUpdate where
+  openAnchors : HashMap String Hl
+  anchorOut : HashMap String Highlighted
+  tacOut : HashMap String Highlighted
+
 /--
 If `line` is an `ANCHOR:`/`ANCHOR_END:`/`PROOF_STATE:` directive, applies it and returns the updated
 anchor and proof-state maps; if it is not a directive, returns `none` (the caller keeps the content).
@@ -298,7 +304,7 @@ anchor and proof-state maps; if it is not a directive, returns `none` (the calle
 private def applyDirective
     (line : String) (preText : Hl) (ctx : Array HlCtx) (textAnchors proofStates : Bool)
     (openAnchors : HashMap String Hl) (anchorOut tacOut : HashMap String Highlighted) :
-    Except String (Option (HashMap String Hl × HashMap String Highlighted × HashMap String Highlighted)) := do
+    Except String (Option DirectiveUpdate) := do
   match guard textAnchors *> (anchor? line |>.toOption) with
   | none =>
     match guard proofStates *> (proofState? line |>.toOption) with
@@ -307,15 +313,15 @@ private def applyDirective
       let some t := preText.tacticsAt? c
         | throw s!"No proof state at column {c} for '{p}'"
       if tacOut.get? p |>.isSome then throw s!"Proof state already found: '{p}'"
-      return some (openAnchors, anchorOut, tacOut.insert p t)
+      return some { openAnchors, anchorOut, tacOut := tacOut.insert p t }
   | some (a, true) =>
     if openAnchors.contains a then throw s!"Anchor already opened: {a}"
     if anchorOut.contains a then throw s!"Anchor already used: {a}"
-    return some (openAnchors.insert a { here := .empty, context := ctx.map (.empty, ·) }, anchorOut, tacOut)
+    return some { openAnchors := openAnchors.insert a { here := .empty, context := ctx.map (.empty, ·) }, anchorOut, tacOut }
   | some (a, false) =>
     let some hl := openAnchors.get? a
       | throw s!"Anchor not open: {a}"
-    return some (openAnchors.erase a, anchorOut.insert a hl.toHighlighted, tacOut)
+    return some { openAnchors := openAnchors.erase a, anchorOut := anchorOut.insert a hl.toHighlighted, tacOut }
 
 /-- Whether `line` is an `ANCHOR:`/`ANCHOR_END:`/`PROOF_STATE:` directive comment. -/
 private def isDirectiveLine (textAnchors proofStates : Bool) (line : String) : Bool :=
@@ -435,7 +441,7 @@ def anchored (hl : Highlighted) (textAnchors := true) (proofStates := true) : Ex
         | none =>
           openAnchors := openAnchors.map fun _ hl => hl ++ line
           doc := doc ++ line
-        | some (oa, ao, to) => openAnchors := oa; anchorOut := ao; tacOut := to
+        | some u => openAnchors := u.openAnchors; anchorOut := u.anchorOut; tacOut := u.tacOut
     | some h@(.token ..) :: hs | some h@(.point ..) :: hs | some h@(.unparsed ..) :: hs =>
       todo := hs
       openAnchors := openAnchors.map fun _ hl => hl ++ h

--- a/src/SubVerso/Highlighting/Anchors/Basic.lean
+++ b/src/SubVerso/Highlighting/Anchors/Basic.lean
@@ -290,21 +290,21 @@ structure AnchoredExamples where
   -/
   proofStates : HashMap String Highlighted
 
-/-- The anchor/proof-state state updated by applying a directive (see `applyDirective`). -/
-private structure DirectiveUpdate where
+/-- The anchor/proof-state state updated by applying a magic comment (see `applyMagicComment`). -/
+private structure MagicCommentUpdate where
   openAnchors : HashMap String Hl
   anchorOut : HashMap String Highlighted
   tacOut : HashMap String Highlighted
 
 /--
-If `line` is an `ANCHOR:`/`ANCHOR_END:`/`PROOF_STATE:` directive, applies it and returns the updated
-anchor and proof-state maps; if it is not a directive, returns `none` (the caller keeps the content).
+If `line` is an `ANCHOR:`/`ANCHOR_END:`/`PROOF_STATE:` magic comment, applies it and returns the
+updated anchor and proof-state maps; if it is not one, returns `none` (the caller keeps the content).
 `preText` is the document the proof-state caret refers into (its last line is the one pointed at).
 -/
-private def applyDirective
+private def applyMagicComment
     (line : String) (preText : Hl) (ctx : Array HlCtx) (textAnchors proofStates : Bool)
     (openAnchors : HashMap String Hl) (anchorOut tacOut : HashMap String Highlighted) :
-    Except String (Option DirectiveUpdate) := do
+    Except String (Option MagicCommentUpdate) := do
   match guard textAnchors *> (anchor? line |>.toOption) with
   | none =>
     match guard proofStates *> (proofState? line |>.toOption) with
@@ -323,8 +323,8 @@ private def applyDirective
       | throw s!"Anchor not open: {a}"
     return some { openAnchors := openAnchors.erase a, anchorOut := anchorOut.insert a hl.toHighlighted, tacOut }
 
-/-- Whether `line` is an `ANCHOR:`/`ANCHOR_END:`/`PROOF_STATE:` directive comment. -/
-private def isDirectiveLine (textAnchors proofStates : Bool) (line : String) : Bool :=
+/-- Whether `line` is an `ANCHOR:`/`ANCHOR_END:`/`PROOF_STATE:` magic comment. -/
+private def isMagicCommentLine (textAnchors proofStates : Bool) (line : String) : Bool :=
   (textAnchors && (anchor? line |>.toOption).isSome) ||
     (proofStates && (proofState? line |>.toOption).isSome)
 
@@ -336,18 +336,13 @@ private def lineStartAfter (atLineStart : Bool) (s : String) : Bool :=
     else false                      -- any other character means content has appeared on the line
 
 /--
-Replaces *directive* comments — tokenized as a `commentDelim` (`--`) followed by a `lineComment` —
-with a single `.text` node holding the reconstructed comment text. After `normHl` merges that text
-with the surrounding whitespace, the line-based directive handling in `anchored` consumes the whole
-directive line (indentation and trailing newline included) exactly as it did before comments were
-tokenized.
+Replaces magic comments with a single `.text` node holding the reconstructed comment text. After
+`normHl` merges that text with the surrounding whitespace, the line-based magic-comment handling
+in `anchored` consumes the whole magic-comment line (indentation and trailing newline included).
 
-Only comments that *begin their line* (preceded by whitespace alone) are eligible, so a trailing
-comment such as `def x := 1 -- ANCHOR: foo` — which is not a directive line — is left as highlighted
-tokens, keeping its styling. The boolean threaded through tracks whether we are at the start of a
-line.
+Only comments that *begin their line* are eligible.
 -/
-private partial def inlineDirectiveCommentsAux (textAnchors proofStates : Bool) (atLineStart : Bool) :
+private partial def inlineMagicCommentsAux (textAnchors proofStates : Bool) (atLineStart : Bool) :
     Highlighted → Highlighted × Bool
   | .text s => (.text s, lineStartAfter atLineStart s)
   | .unparsed s => (.unparsed s, lineStartAfter atLineStart s)
@@ -357,32 +352,32 @@ private partial def inlineDirectiveCommentsAux (textAnchors proofStates : Bool) 
     let (xs', a) := goSeq atLineStart xs.toList
     (.seq xs'.toArray, a)
   | .span info x =>
-    let (x', a) := inlineDirectiveCommentsAux textAnchors proofStates atLineStart x
+    let (x', a) := inlineMagicCommentsAux textAnchors proofStates atLineStart x
     (.span info x', a)
   | .tactics info s e x =>
-    let (x', a) := inlineDirectiveCommentsAux textAnchors proofStates atLineStart x
+    let (x', a) := inlineMagicCommentsAux textAnchors proofStates atLineStart x
     (.tactics info s e x', a)
 where
   goSeq (atLineStart : Bool) : List Highlighted → List Highlighted × Bool
     | .token ⟨.commentDelim, delim⟩ :: .token ⟨.lineComment, body⟩ :: rest =>
-      if atLineStart && isDirectiveLine textAnchors proofStates (delim ++ body) then
+      if atLineStart && isMagicCommentLine textAnchors proofStates (delim ++ body) then
         let (rest', a) := goSeq false rest
         (.text (delim ++ body) :: rest', a)
       else
         let (rest', a) := goSeq false rest
         (.token ⟨.commentDelim, delim⟩ :: .token ⟨.lineComment, body⟩ :: rest', a)
     | x :: rest =>
-      let (x', a) := inlineDirectiveCommentsAux textAnchors proofStates atLineStart x
+      let (x', a) := inlineMagicCommentsAux textAnchors proofStates atLineStart x
       let (rest', a') := goSeq a rest
       (x' :: rest', a')
     | [] => ([], atLineStart)
 
-/-- Top-level entry: see `inlineDirectiveCommentsAux`. The document starts at the start of a line. -/
-private def inlineDirectiveComments (textAnchors proofStates : Bool) (hl : Highlighted) : Highlighted :=
-  (inlineDirectiveCommentsAux textAnchors proofStates true hl).1
+/-- Top-level entry: see `inlineMagicCommentsAux`. The document starts at the start of a line. -/
+private def inlineMagicComments (textAnchors proofStates : Bool) (hl : Highlighted) : Highlighted :=
+  (inlineMagicCommentsAux textAnchors proofStates true hl).1
 
 /--
-Extracts code from rendered examples based on comment directives.
+Extracts code from rendered examples based on magic comments.
 
 There are two kinds of extracted code: anchors and named proof states. Anchors name one or more
 lines of code:
@@ -415,11 +410,11 @@ def anchored (hl : Highlighted) (textAnchors := true) (proofStates := true) : Ex
   let mut tacOut : HashMap String Highlighted := {}
   let mut openAnchors : HashMap String Hl := {}
   let mut doc : Hl := .empty
-  -- Directive comments (`-- ANCHOR: …`, `-- PROOF_STATE: …`) are tokenized as
+  -- Magic comments (`-- ANCHOR: …`, `-- PROOF_STATE: …`) are tokenized as
   -- `commentDelim`/`lineComment` rather than plain `.text`. Turn just those back into a single
-  -- `.text` node so the line-based directive handling below consumes the whole directive line
-  -- (after `normHl` re-merges the surrounding whitespace); non-directive comments stay as tokens.
-  let mut todo := [some (normHl (inlineDirectiveComments textAnchors proofStates (normHl hl)))]
+  -- `.text` node so the line-based magic-comment handling below consumes the whole magic-comment
+  -- line (after `normHl` re-merges the surrounding whitespace); ordinary comments stay as tokens.
+  let mut todo := [some (normHl (inlineMagicComments textAnchors proofStates (normHl hl)))]
   let mut ctx : Array HlCtx := #[]
   repeat
     match todo with
@@ -437,7 +432,7 @@ def anchored (hl : Highlighted) (textAnchors := true) (proofStates := true) : Ex
       todo := hs
       let lines := Internal.getLines s
       for line in lines do
-        match ← applyDirective line preText ctx textAnchors proofStates openAnchors anchorOut tacOut with
+        match ← applyMagicComment line preText ctx textAnchors proofStates openAnchors anchorOut tacOut with
         | none =>
           openAnchors := openAnchors.map fun _ hl => hl ++ line
           doc := doc ++ line

--- a/src/SubVerso/Highlighting/Anchors/Basic.lean
+++ b/src/SubVerso/Highlighting/Anchors/Basic.lean
@@ -322,27 +322,58 @@ private def isDirectiveLine (textAnchors proofStates : Bool) (line : String) : B
   (textAnchors && (anchor? line |>.toOption).isSome) ||
     (proofStates && (proofState? line |>.toOption).isSome)
 
+/-- Whether, after emitting `s`, we are at the start of a line (only whitespace since a newline). -/
+private def lineStartAfter (atLineStart : Bool) (s : String) : Bool :=
+  s.foldl (init := atLineStart) fun atStart c =>
+    if c == '\n' then true          -- a newline begins a fresh line
+    else if c.isWhitespace then atStart   -- whitespace keeps the current line-start status
+    else false                      -- any other character means content has appeared on the line
+
 /--
 Replaces *directive* comments — tokenized as a `commentDelim` (`--`) followed by a `lineComment` —
 with a single `.text` node holding the reconstructed comment text. After `normHl` merges that text
 with the surrounding whitespace, the line-based directive handling in `anchored` consumes the whole
 directive line (indentation and trailing newline included) exactly as it did before comments were
-tokenized. Non-directive comments are left as highlighted tokens so they keep their styling.
+tokenized.
+
+Only comments that *begin their line* (preceded by whitespace alone) are eligible, so a trailing
+comment such as `def x := 1 -- ANCHOR: foo` — which is not a directive line — is left as highlighted
+tokens, keeping its styling. The boolean threaded through tracks whether we are at the start of a
+line.
 -/
-private partial def inlineDirectiveComments (textAnchors proofStates : Bool) : Highlighted → Highlighted
-  | .seq xs => .seq (goSeq xs.toList).toArray
-  | .span info x => .span info (inlineDirectiveComments textAnchors proofStates x)
-  | .tactics info s e x => .tactics info s e (inlineDirectiveComments textAnchors proofStates x)
-  | hl => hl
+private partial def inlineDirectiveCommentsAux (textAnchors proofStates : Bool) (atLineStart : Bool) :
+    Highlighted → Highlighted × Bool
+  | .text s => (.text s, lineStartAfter atLineStart s)
+  | .unparsed s => (.unparsed s, lineStartAfter atLineStart s)
+  | .point k i => (.point k i, atLineStart)
+  | .token t => (.token t, false)
+  | .seq xs =>
+    let (xs', a) := goSeq atLineStart xs.toList
+    (.seq xs'.toArray, a)
+  | .span info x =>
+    let (x', a) := inlineDirectiveCommentsAux textAnchors proofStates atLineStart x
+    (.span info x', a)
+  | .tactics info s e x =>
+    let (x', a) := inlineDirectiveCommentsAux textAnchors proofStates atLineStart x
+    (.tactics info s e x', a)
 where
-  goSeq : List Highlighted → List Highlighted
+  goSeq (atLineStart : Bool) : List Highlighted → List Highlighted × Bool
     | .token ⟨.commentDelim, delim⟩ :: .token ⟨.lineComment, body⟩ :: rest =>
-      if isDirectiveLine textAnchors proofStates (delim ++ body) then
-        .text (delim ++ body) :: goSeq rest
+      if atLineStart && isDirectiveLine textAnchors proofStates (delim ++ body) then
+        let (rest', a) := goSeq false rest
+        (.text (delim ++ body) :: rest', a)
       else
-        .token ⟨.commentDelim, delim⟩ :: .token ⟨.lineComment, body⟩ :: goSeq rest
-    | x :: rest => inlineDirectiveComments textAnchors proofStates x :: goSeq rest
-    | [] => []
+        let (rest', a) := goSeq false rest
+        (.token ⟨.commentDelim, delim⟩ :: .token ⟨.lineComment, body⟩ :: rest', a)
+    | x :: rest =>
+      let (x', a) := inlineDirectiveCommentsAux textAnchors proofStates atLineStart x
+      let (rest', a') := goSeq a rest
+      (x' :: rest', a')
+    | [] => ([], atLineStart)
+
+/-- Top-level entry: see `inlineDirectiveCommentsAux`. The document starts at the start of a line. -/
+private def inlineDirectiveComments (textAnchors proofStates : Bool) (hl : Highlighted) : Highlighted :=
+  (inlineDirectiveCommentsAux textAnchors proofStates true hl).1
 
 /--
 Extracts code from rendered examples based on comment directives.

--- a/src/SubVerso/Highlighting/Anchors/Basic.lean
+++ b/src/SubVerso/Highlighting/Anchors/Basic.lean
@@ -317,6 +317,33 @@ private def applyDirective
       | throw s!"Anchor not open: {a}"
     return some (openAnchors.erase a, anchorOut.insert a hl.toHighlighted, tacOut)
 
+/-- Whether `line` is an `ANCHOR:`/`ANCHOR_END:`/`PROOF_STATE:` directive comment. -/
+private def isDirectiveLine (textAnchors proofStates : Bool) (line : String) : Bool :=
+  (textAnchors && (anchor? line |>.toOption).isSome) ||
+    (proofStates && (proofState? line |>.toOption).isSome)
+
+/--
+Replaces *directive* comments — tokenized as a `commentDelim` (`--`) followed by a `lineComment` —
+with a single `.text` node holding the reconstructed comment text. After `normHl` merges that text
+with the surrounding whitespace, the line-based directive handling in `anchored` consumes the whole
+directive line (indentation and trailing newline included) exactly as it did before comments were
+tokenized. Non-directive comments are left as highlighted tokens so they keep their styling.
+-/
+private partial def inlineDirectiveComments (textAnchors proofStates : Bool) : Highlighted → Highlighted
+  | .seq xs => .seq (goSeq xs.toList).toArray
+  | .span info x => .span info (inlineDirectiveComments textAnchors proofStates x)
+  | .tactics info s e x => .tactics info s e (inlineDirectiveComments textAnchors proofStates x)
+  | hl => hl
+where
+  goSeq : List Highlighted → List Highlighted
+    | .token ⟨.commentDelim, delim⟩ :: .token ⟨.lineComment, body⟩ :: rest =>
+      if isDirectiveLine textAnchors proofStates (delim ++ body) then
+        .text (delim ++ body) :: goSeq rest
+      else
+        .token ⟨.commentDelim, delim⟩ :: .token ⟨.lineComment, body⟩ :: goSeq rest
+    | x :: rest => inlineDirectiveComments textAnchors proofStates x :: goSeq rest
+    | [] => []
+
 /--
 Extracts code from rendered examples based on comment directives.
 
@@ -351,18 +378,12 @@ def anchored (hl : Highlighted) (textAnchors := true) (proofStates := true) : Ex
   let mut tacOut : HashMap String Highlighted := {}
   let mut openAnchors : HashMap String Hl := {}
   let mut doc : Hl := .empty
-  let mut todo := [some (normHl hl)]
+  -- Directive comments (`-- ANCHOR: …`, `-- PROOF_STATE: …`) are tokenized as
+  -- `commentDelim`/`lineComment` rather than plain `.text`. Turn just those back into a single
+  -- `.text` node so the line-based directive handling below consumes the whole directive line
+  -- (after `normHl` re-merges the surrounding whitespace); non-directive comments stay as tokens.
+  let mut todo := [some (normHl (inlineDirectiveComments textAnchors proofStates (normHl hl)))]
   let mut ctx : Array HlCtx := #[]
-  -- State for reconstructing directives from comment tokens (`-- ANCHOR: …`, `-- PROOF_STATE: …`),
-  -- which are now tokenized as `commentDelim`/`lineComment` rather than appearing as plain `.text`:
-  --  * `docBeforeLine` is a snapshot of `doc` taken at the start of the most recent `.text` node. A
-  --    directive comment is always preceded by the whitespace run holding the newline that ends the
-  --    previous line, so when a comment is reached this is `doc` through the end of that previous
-  --    line: its last line is the one a `PROOF_STATE` caret refers to, which `tacticsAt?` searches.
-  --  * `curLineText` is the current line's text so far (after the last newline) — i.e. the comment's
-  --    indentation — used to rebuild the full comment line so proof-state columns stay absolute.
-  let mut docBeforeLine : Hl := .empty
-  let mut curLineText : String := ""
   repeat
     match todo with
     | [] => break
@@ -376,10 +397,6 @@ def anchored (hl : Highlighted) (textAnchors := true) (proofStates := true) : Ex
       -- of comments, in case proof state indicator comments are mixed up with other kinds of
       -- comments.
       let preText := doc
-      -- Snapshot `doc` before this text node for a following comment-token directive: when the next
-      -- node is a directive comment, this text node is the whitespace run starting with the newline
-      -- that ends the previous line, so `docBeforeLine` then holds `doc` through that previous line.
-      docBeforeLine := doc
       todo := hs
       let lines := Internal.getLines s
       for line in lines do
@@ -388,25 +405,6 @@ def anchored (hl : Highlighted) (textAnchors := true) (proofStates := true) : Ex
           openAnchors := openAnchors.map fun _ hl => hl ++ line
           doc := doc ++ line
         | some (oa, ao, to) => openAnchors := oa; anchorOut := ao; tacOut := to
-      -- Track the current source line's trailing text (the part after the last newline) so that a
-      -- following comment-token directive can be reconstructed with its original indentation.
-      if lines.size > 1 then curLineText := Compat.Array.back! lines
-      else curLineText := curLineText ++ s
-    | some (.token ⟨.commentDelim, delim⟩) :: some (.token ⟨.lineComment, body⟩) :: hs =>
-      -- A line comment is tokenized as a `--` delimiter plus its body. Reconstruct the original
-      -- comment line (with this line's indentation) so `-- ANCHOR: …` / `-- PROOF_STATE: …`
-      -- directives are still recognized. Non-directive comments are kept as highlighted tokens.
-      -- `docBeforeLine` ends at the previous line, so its last line is the one a `^` would point at.
-      let line := curLineText ++ delim ++ body
-      todo := hs
-      match ← applyDirective line docBeforeLine ctx textAnchors proofStates openAnchors anchorOut tacOut with
-      | none =>
-        let cd : Highlighted := .token ⟨.commentDelim, delim⟩
-        let lc : Highlighted := .token ⟨.lineComment, body⟩
-        openAnchors := openAnchors.map fun _ hl => hl ++ cd ++ lc
-        doc := doc ++ cd ++ lc
-        curLineText := curLineText ++ delim ++ body
-      | some (oa, ao, to) => openAnchors := oa; anchorOut := ao; tacOut := to
     | some h@(.token ..) :: hs | some h@(.point ..) :: hs | some h@(.unparsed ..) :: hs =>
       todo := hs
       openAnchors := openAnchors.map fun _ hl => hl ++ h

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -1740,6 +1740,33 @@ they are name-escaping syntax.
 def isBracketChar (c : Char) : Bool :=
   "()[]{}⟨⟩⦃⦄⟦⟧⟪⟫‹›⌊⌋⌈⌉".contains c
 
+/--
+Whether `c` is a mathematical alphabetic letter: a script, fraktur, double-struck, bold, italic, or
+sans-serif letter from the Mathematical Alphanumeric Symbols block, or one of the script/fraktur/
+double-struck letterlike forms (`ℬ`, `ℰ`, `ℱ`, `ℋ`, `ℐ`, `ℒ`, `ℳ`, `ℛ`, `ℓ`, `℘`, `ℕ`, `ℝ`, …) that
+live in the Letterlike Symbols block. `Char.isAlpha` only recognizes ASCII letters, so these
+must be matched explicitly.
+-/
+def isMathematicalLetter (c : Char) : Bool :=
+  let v := c.toNat
+  -- Mathematical Alphanumeric Symbols, letters & Greek (the digits at 0x1D7CE–0x1D7FF are excluded)
+  (0x1D400 ≤ v && v ≤ 0x1D7CB) ||
+    -- script/fraktur/double-struck letters carved out into the Letterlike Symbols block
+    "ℬℰℱℋℐℒℳℛℯℊℴℓ℘ℂℍℕℙℚℝℤℨℭℌℑℜ".contains c
+
+/--
+Characters that may decorate a bracket atom alongside its bracket character(s). Some brackets
+combine a bracket character with other characters:
+* a letter (ASCII or mathematical) — a user `notation` like `foo[ … ]` or `𝒜[ … ]` produces a
+  bracket-like `foo[`/`𝒜[` token;
+* `#` — `#[` (array) and `#v[` (`Vector`);
+* `%` — `%[` (list cons-notation);
+* `'` — `]'` (`getElem` with a proof, `xs[i]'h`);
+* `!`/`?` — brackets such as `{! … !}`.
+-/
+def isBracketExtra (c : Char) : Bool :=
+  c.isAlpha || isMathematicalLetter c || c == '#' || c == '%' || c == '\'' || c == '!' || c == '?'
+
 /-- Whether `c` is an item-separator character. -/
 def isSeparatorChar (c : Char) : Bool := c == ',' || c == ';'
 
@@ -1778,15 +1805,17 @@ Lexically classifies a symbolic atom that `identKind` did not resolve to a const
 `ℕ` in Mathlib), meaning that no elaboration info matches its exact span.
 
 This is a best-effort heuristic based on the characters in the atom. An atom made entirely of
-separator or bracket characters is classified accordingly. An operator must contain at least one
-operator character, with every character being an operator, subscript, or superscript (so a
-decorated operator like `→ₗ` or `→ᵇ` counts, but a bare letter-like symbol such as `𝒫` does not).
-Anything else stays `.unknown` rather than being assumed to be an operator.
+separator characters is a separator. A bracket must contain at least one bracket character, with
+every character being a bracket or a bracket extra (so `#[`, `%[`, and `]'` count). An operator must
+contain at least one operator character, with every character being an operator, subscript, or
+superscript (so a decorated operator like `→ₗ` or `→ᵇ` counts, but a bare letter-like symbol such as
+`𝒫` does not). Anything else stays `.unknown` rather than being assumed to be an operator.
 -/
 def atomKind (name : Option Name) (occ : Option String) (docs : Option String) (s : String) : Token.Kind :=
   if s.isEmpty then .unknown
   else if s.all isSeparatorChar then .separator name occ docs
-  else if s.all isBracketChar then .bracket name occ docs
+  else if s.any isBracketChar && s.all (fun c => isBracketChar c || isBracketExtra c) then
+    .bracket name occ docs
   else if s.any isOperatorChar && s.all (fun c => isOperatorChar c || isSubOrSuperscript c) then
     .operator name occ docs
   else .unknown
@@ -1854,21 +1883,29 @@ partial def highlight'
           emitToken stx i ⟨.sort docs?, x⟩
       | .unknown =>
         -- `identKind` didn't match this to an identifier, so it's not something akin to Mathlib's
-        -- `ℕ`. No elaboration info matches its exact span. If it reads as a keyword (alphabetic,
-        -- `#`-prefixed, or one of the curated core symbolic keywords) emit `.keyword`; otherwise it
-        -- is punctuation, classified lexically per character (operator/bracket/separator).
-        let isKeyword :=
-          match Compat.String.Pos.get? x 0 with
-          | some '#' =>
-            match Compat.String.Pos.get? x ((0 : Compat.String.Pos) + '#') with
-            | some c => c.isAlpha
-            | _ => false
-          | some c => c.isAlpha || isSymbolicKeyword x
-          | _ => false
-        if isKeyword then
+        -- `ℕ`; no elaboration info matches its exact span. Classify it lexically:
+        --  * a curated core symbolic keyword (`:=`, `=>`, …) is a `.keyword` — checked first so it
+        --    wins over the operator classification below;
+        --  * otherwise `atomKind` classifies punctuation (separator/bracket/operator), and notably a
+        --    bracket-like atom such as `foo[` wins over the keyword heuristic even though it starts
+        --    with a letter;
+        --  * a remaining alphabetic or `#`-prefixed atom is a `.keyword`.
+        if isSymbolicKeyword x then
           emitToken stx i ⟨.keyword name occ docs, x⟩
         else
-          emitToken stx i ⟨atomKind name occ docs x, x⟩
+          match atomKind name occ docs x with
+          | .unknown =>
+            let isKeyword :=
+              match Compat.String.Pos.get? x 0 with
+              | some '#' =>
+                match Compat.String.Pos.get? x ((0 : Compat.String.Pos) + '#') with
+                | some c => c.isAlpha
+                | _ => false
+              | some c => c.isAlpha
+              | _ => false
+            if isKeyword then emitToken stx i ⟨.keyword name occ docs, x⟩
+            else emitToken stx i ⟨.unknown, x⟩
+          | k => emitToken stx i ⟨k, x⟩
       | _ =>
         -- A nullary notation or symbol constant (e.g. `ℕ`, `ℤ`, `ℝ`) whose canonical span is
         -- exactly this atom resolved span-exact via `identKind`; keep its semantic kind.

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -94,6 +94,9 @@ partial def Token.Kind.priority : Token.Kind → Nat
   | .moduleName .. => 4
   | .keyword .. => 3
   | .levelConst .. | .levelVar .. | .levelOp .. => 4
+  | .num .. | .char .. => 3
+  | .operator .. | .bracket .. | .separator .. => 1
+  | .lineComment | .blockComment | .commentDelim => 1
   | .docComment | .withType .. => 1
   | .unknown => 0
 
@@ -937,6 +940,124 @@ def collectMessageBoundariesBetween (startPos endPos : Compat.String.Pos)
             boundaries := boundaries.insert msgEndPosUtf8
   return boundaries
 
+/-- The current character of a string iterator, or `none` at the end. -/
+private def peekChar (iter : Compat.String.Iterator) : Option Char :=
+  if h : iter.hasNext then some (iter.curr' h) else none
+
+/-- Emits an accumulated whitespace run as text, or as unparsed source when `unparsed` is set. -/
+private def emitTriviaText (unparsed : Bool) (s : String) : HighlightM Unit :=
+  unless s.isEmpty do
+    modify fun st => { st with
+      output :=
+        if unparsed then
+          Output.addUnparsed st.output s
+        else Output.addText st.output s
+    }
+
+/-- Emits a non-empty trivia token of the given kind. -/
+private def emitTriviaToken (k : Token.Kind) (s : String) : HighlightM Unit :=
+  unless s.isEmpty do
+    modify fun st => { st with
+      output := Output.addToken st.output ⟨k, s⟩
+    }
+
+/--
+Emits a line comment as a `.commentDelim` opener (`--`) followed by a `.lineComment` body, scanning
+from `iter` (positioned just after the `--`) up to but not including the terminating newline.
+Returns the iterator at the next new line, or end of string, whichever is first.
+-/
+def emitLineComment (start : Compat.String.Iterator) : HighlightM Compat.String.Iterator := do
+  emitTriviaToken .commentDelim "--"
+  let mut iter := start
+  while h : iter.hasNext do
+    if iter.curr' h == '\n' then break
+    iter := iter.next
+  -- `iter` is now at the newline (left for the following whitespace run) or at the end.
+  emitTriviaToken .lineComment (start.extract iter)
+  return iter
+
+/--
+Emits a depth-balanced (nesting) block comment, scanning from `iter` (positioned just after the
+opening `/-`). Each opener `/-` and closer `-/` (including nested ones) is emitted as a
+`.commentDelim` token; the text between delimiters is emitted as `.blockComment`. Returns the
+iterator just past the outermost closing `-/` (or at end if unterminated).
+-/
+def emitBlockComment (start : Compat.String.Iterator) : HighlightM (Option Compat.String.Iterator) := do
+  -- Scan (without emitting) for the depth-balanced closing `-/`, tracking whether the previous
+  -- character was a lone `/` or `-`. An unterminated comment emits nothing and returns `none`, so
+  -- the caller can fall back to plain text.
+  let mut iter := start
+  let mut depth := 1
+  let mut sawSlash := false
+  let mut sawDash := false
+  let mut bodyEnd := start
+  let mut afterClose := start
+  let mut terminated := false
+  while h : iter.hasNext do
+    let c := iter.curr' h
+    let iter' := iter.next' h
+    if c == '/' && sawDash then
+      depth := depth - 1
+      sawSlash := false
+      sawDash := false
+      if depth == 0 then
+        bodyEnd := iter.prev   -- the `-` of the closing `-/`
+        afterClose := iter'
+        terminated := true
+        break
+    else if c == '-' && sawSlash then
+      depth := depth + 1
+      sawSlash := false
+      sawDash := false
+    else
+      sawSlash := c == '/'
+      sawDash := c == '-'
+    iter := iter'
+  if terminated then
+    emitTriviaToken .commentDelim "/-"
+    emitTriviaToken .blockComment (start.extract bodyEnd)
+    emitTriviaToken .commentDelim "-/"
+    return some afterClose
+  else
+    return none
+
+/--
+Splits a whitespace-and-comment trivia string into whitespace runs and comment tokens, emitting
+each to the output in source order. Comment delimiters (`--`, `/-`, `-/`) are emitted as
+`.commentDelim` tokens, distinct from the `.lineComment`/`.blockComment` body text. Doc comments are
+real syntax nodes and thus handled elsewhere.
+-/
+def emitTrivia (s : String) (unparsed : Bool := false) : HighlightM Unit := do
+  -- Fast path: a comment can only contain `-` or `/`, so a string without either is pure
+  -- whitespace and is emitted as a single run (matching the previous behavior exactly).
+  if !s.any (fun c => c == '-' || c == '/') then
+    emitTriviaText unparsed s
+    return
+  -- `runStart` marks the beginning of the current whitespace run; `iter` scans ahead. When a
+  -- comment opener is found, the run `[runStart, iter)` is flushed and the comment is emitted.
+  let mut iter := s.compatIter
+  let mut runStart := iter
+  while h : iter.hasNext do
+    let c := iter.curr' h
+    let next := iter.next' h
+    if c == '-' && peekChar next == some '-' then
+      emitTriviaText unparsed (runStart.extract iter)
+      iter := (← emitLineComment next.next)
+      runStart := iter
+    else if c == '/' && peekChar next == some '-' then
+      emitTriviaText unparsed (runStart.extract iter)
+      match (← emitBlockComment next.next) with
+      | some iter' =>
+        iter := iter'
+        runStart := iter
+      | none =>
+        -- Unterminated block comment: nothing was emitted, so leave the `/-` in the (text) run.
+        runStart := iter
+        iter := next
+    else
+      iter := next
+  emitTriviaText unparsed (runStart.extract iter)
+
 /-- Adds to the output any source (if any exists) lying between the last added position and `pos`. -/
 def fillMissingSourceUpTo (pos : Compat.String.Pos) : HighlightM Unit := do
   if let some lastPos := (← get).lastPos? then
@@ -950,7 +1071,7 @@ def fillMissingSourceUpTo (pos : Compat.String.Pos) : HighlightM Unit := do
         let endPos := boundaries[i]!
         openUntil <| text.toPosition startPos
         let string := Compat.Substring.mk text.source startPos endPos |>.toString
-        modify fun st => {st with output := Output.addUnparsed st.output string}
+        emitTrivia string (unparsed := true)
         closeUntil endPos
         setLastPos endPos
 
@@ -978,11 +1099,11 @@ def emitToken (blame : Syntax) (info : SourceInfo) (token : Token) : HighlightM 
         throwError "Syntax {blame} not original, can't highlight: '{str}'"
       | _ => throwError "Syntax {blame} not original, can't highlight: {repr info}"
 
-  emitString' leading.toString
+  emitTrivia leading.toString
   openUntil <| text.toPosition pos
   modify fun st => {st with output := Output.addToken st.output token}
   closeUntil endPos
-  emitString' trailing.toString
+  emitTrivia trailing.toString
   let trailingPos := Internal.getTrailingOrTailPos? blame
   setLastPos trailingPos
 
@@ -1572,6 +1693,71 @@ def highlightSpecial
     hl trees tactics none rhs
   | _ => hl trees tactics lookingAt stx
 
+/--
+These atoms will not be considered punctuation.
+-/
+def isSymbolicKeyword (s : String) : Bool :=
+  s == ":=" || s == "=>" || s == "↦" || s == "←" || s == "@" || s == ":" ||
+  s == "⊢" || s == "|" || s == ".." || s == "..."
+
+/--
+Whether `c` is a paired-delimiter (bracket) character. Note that `«` `»` are *not* brackets because
+they are name-escaping syntax.
+-/
+def isBracketChar (c : Char) : Bool :=
+  "()[]{}⟨⟩⦃⦄⟦⟧⟪⟫‹›⌊⌋⌈⌉".contains c
+
+/-- Whether `c` is an item-separator character. -/
+def isSeparatorChar (c : Char) : Bool := c == ',' || c == ';'
+
+/--
+Whether `c` is an operator character: an ASCII operator symbol, or a Unicode *mathematical symbol*
+that Lean uses to build operators. This is deliberately a set of operator-like *symbols*, not
+letter-like notation: script/fraktur/blackboard letters (`𝒫`, `ℬ`, …) and Greek letters are not
+operators, so an atom containing them stays `.unknown` rather than being assumed to be an operator.
+
+This is a partial, heuristic characterization.
+-/
+def isOperatorChar (c : Char) : Bool :=
+  -- ASCII operator symbols
+  "!%&*+-/<=>?^|~:.".contains c ||
+    -- arrows: short, long, wavy/squiggly, hooked, tailed, two-headed, up/down, harpoons, and the
+    -- category-theory functor arrows
+    "→←↔↦↤↣↢↪↩↠↞⟶⟵⟷⟸⟹⟺⟼⟻⟽⟾⟿⇒⇐⇔⇉⇇⇈⇊⇛⇚↑↓↕⇑⇓⇕↥↧↟↡⟰⟱⇀↼⇁↽⇌⇋⥤⥥↝↜⇝⇜⤳↭⇿⤇⤆".contains c ||
+    -- logic, relation, set, and algebraic operator symbols, plus superscript/subscript operator
+    -- signs (so e.g. the `⁻` in `⁻¹` is an operator character)
+    "∘∧∨¬±∓×÷∣∥≤≥≠≡≃≅≈∼≪≫∈∉∋⊆⊂⊇⊃∪∩∖⊔⊓⊕⊗⊙⊖⊞⊠⋆∗∙⬝•⋄⋅⁺⁻⁼₊₋₌".contains c
+
+/--
+Whether `c` is a subscript or superscript letter, digit, or sign. These decorate operators (e.g.
+the `ₗ` in `→ₗ`, the `ᵇ` in `→ᵇ`, or the `¹` in `⁻¹`) but are never operators on their own.
+-/
+def isSubOrSuperscript (c : Char) : Bool :=
+  let v := c.toNat
+  v == 0xB2 || v == 0xB3 || v == 0xB9 ||      -- ² ³ ¹
+    (0x2B0 ≤ v && v ≤ 0x2FF) ||               -- spacing modifier letters: ʰ ʲ ˡ ʳ ˢ ˣ ʸ …
+    (0x1D2C ≤ v && v ≤ 0x1DBF) ||             -- phonetic-extension super/subscript letters: ᵃ ᵇ ᶜ ᵢ ᵣ …
+    (0x2070 ≤ v && v ≤ 0x209C) ||             -- superscripts & subscripts block: ⁰ ⁻ ⁿ … ₀ ₋ ₓ …
+    v == 0x2C7C                               -- ⱼ
+
+/--
+Lexically classifies a symbolic atom that `identKind` did not resolve to a constant-like term (e.g.
+`ℕ` in Mathlib), meaning that no elaboration info matches its exact span.
+
+This is a best-effort heuristic based on the characters in the atom. An atom made entirely of
+separator or bracket characters is classified accordingly. An operator must contain at least one
+operator character, with every character being an operator, subscript, or superscript (so a
+decorated operator like `→ₗ` or `→ᵇ` counts, but a bare letter-like symbol such as `𝒫` does not).
+Anything else stays `.unknown` rather than being assumed to be an operator.
+-/
+def atomKind (name : Option Name) (occ : Option String) (docs : Option String) (s : String) : Token.Kind :=
+  if s.isEmpty then .unknown
+  else if s.all isSeparatorChar then .separator name occ docs
+  else if s.all isBracketChar then .bracket name occ docs
+  else if s.any isOperatorChar && s.all (fun c => isOperatorChar c || isSubOrSuperscript c) then
+    .operator name occ docs
+  else .unknown
+
 partial def highlight'
     (trees : Array Lean.Elab.InfoTree)
     (stx : Syntax)
@@ -1628,23 +1814,33 @@ partial def highlight'
         | some (n, _) => findDocString? (← getEnv) n
       let name := lookingAt.map (·.1)
       let occ := lookingAt.map fun (n, pos) => s!"{n}-{pos}"
-      if let .sort docs? ← identKind trees ⟨stx⟩ then
+      let k ← identKind trees ⟨stx⟩
+      match k with
+      | .sort docs? =>
         withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Sort") do
           emitToken stx i ⟨.sort docs?, x⟩
-        return
-      else
-        emitToken stx i <| (⟨ ·,  x⟩) <|
-        match Compat.String.Pos.get? x 0 with
-        | some '#' =>
-          match Compat.String.Pos.get? x ((0 : Compat.String.Pos) + '#') with
-          | some c =>
-            if c.isAlpha then .keyword name occ docs
-            else .unknown
-          | _ => .unknown
-        | some c =>
-          if c.isAlpha then .keyword name occ docs
-          else .unknown
-        | _ => .unknown
+      | .unknown =>
+        -- `identKind` didn't match this to an identifier, so it's not something akin to Mathlib's
+        -- `ℕ`. No elaboration info matches its exact span. If it reads as a keyword (alphabetic,
+        -- `#`-prefixed, or one of the curated core symbolic keywords) emit `.keyword`; otherwise it
+        -- is punctuation, classified lexically per character (operator/bracket/separator).
+        let isKeyword :=
+          match Compat.String.Pos.get? x 0 with
+          | some '#' =>
+            match Compat.String.Pos.get? x ((0 : Compat.String.Pos) + '#') with
+            | some c => c.isAlpha
+            | _ => false
+          | some c => c.isAlpha || isSymbolicKeyword x
+          | _ => false
+        if isKeyword then
+          emitToken stx i ⟨.keyword name occ docs, x⟩
+        else
+          emitToken stx i ⟨atomKind name occ docs x, x⟩
+      | _ =>
+        -- A nullary notation or symbol constant (e.g. `ℕ`, `ℤ`, `ℝ`) whose canonical span is
+        -- exactly this atom resolved span-exact via `identKind`; keep its semantic kind.
+        withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Resolved atom is {repr k}") do
+          emitToken stx i ⟨k, x⟩
     | stx@(.node _ `Lean.Parser.Command.versoCommentBody _) =>
       if let some endPos := Compat.getTrailingTailPos? stx then
         fillMissingSourceUpTo endPos
@@ -1658,12 +1854,29 @@ partial def highlight'
         emitToken stx i ⟨.str s, string⟩
       else
         emitToken stx i ⟨.unknown, string⟩
-    | .node _ `num #[.atom i n] =>
+    | .node _ `char #[.atom i c] =>
+      withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Char") do
+      if let some ch := Syntax.decodeCharLit c then
+        emitToken stx i ⟨.char ch, c⟩
+      else
+        emitToken stx i ⟨.unknown, c⟩
+    | .node _ `num #[.atom i n] | .node _ `scientific #[.atom i n] =>
       withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Numeral") do
+        -- Keep the inferred type (if any) for hover, but emit a dedicated numeric kind.
         let k ← identKind trees ⟨stx⟩ (allowUnknownTyped := true)
-        emitToken stx i ⟨k, n⟩
+        let numKind := match k with
+          | .withType t => .num (some t) none
+          | _ => .num none none
+        emitToken stx i ⟨numKind, n⟩
     | .node _ ``Lean.Parser.Command.docComment #[.atom i1 opener, .atom i2 body] =>
       withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Doc comment") do
+      if let .original leading pos ws _ := i1 then
+        if let .original ws' _ trailing endPos := i2 then
+          emitToken stx (.original leading pos trailing endPos) ⟨.docComment, opener ++ ws.toString ++ ws'.toString ++ body⟩
+          return
+      emitString' (opener ++ " " ++ body ++ "\n")
+    | .node _ ``Lean.Parser.Command.moduleDoc #[.atom i1 opener, .atom i2 body] =>
+      withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Module doc") do
       if let .original leading pos ws _ := i1 then
         if let .original ws' _ trailing endPos := i2 then
           emitToken stx (.original leading pos trailing endPos) ⟨.docComment, opener ++ ws.toString ++ ws'.toString ++ body⟩
@@ -1712,8 +1925,13 @@ partial def highlight'
       else
         withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Other node, kind {k}, with {children.size} children") do
         let pos := stx.getPos?
+        -- A `null` node is an anonymous grouping (`sepBy`, `optional`, `many`, …) with no production
+        -- identity of its own. Attributing its children to the meaningless `null` kind produces
+        -- useless names/occurrences (e.g. a separator `,` tagged `null-30970`), so let them inherit
+        -- the surrounding `lookingAt` instead.
+        let childLookingAt := if k == nullKind then lookingAt else pos.map (k, ·)
         for child in children do
-          highlight' trees child tactics (lookingAt := pos.map (k, ·))
+          highlight' trees child tactics (lookingAt := childLookingAt)
 
 def sortSuppress (nss : List Name) : List Name :=
   nss.toArray.qsort (fun x y => x.components.length > y.components.length) |>.toList

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -1665,7 +1665,7 @@ def highlightSpecial
       withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Highlighting projection {e} {tk} {field}") do
       hl trees tactics none e
       if let some ⟨pos, endPos⟩ := tk.getRange? then
-        emitToken stx tk.getHeadInfo <| .mk .unknown <| Compat.String.Pos.extract (← getFileMap).source pos endPos
+        emitToken stx tk.getHeadInfo <| .mk (.delim none none none) <| Compat.String.Pos.extract (← getFileMap).source pos endPos
       else
         emitString' "."
       hl trees tactics none field
@@ -1733,7 +1733,8 @@ These atoms will not be considered punctuation.
 -/
 def isSymbolicKeyword (s : String) : Bool :=
   s == ":=" || s == "=>" || s == "↦" || s == "←" || s == "@" || s == ":" ||
-  s == "⊢" || s == "|" || s == ".." || s == "..."
+  s == "⊢" || s == "|" ||
+  (!s.isEmpty && s.all (· == '.'))
 
 /--
 Whether `c` is a paired-delimiter (bracket) character. Note that `«` `»` are *not* brackets because
@@ -1852,7 +1853,7 @@ partial def highlight'
             if (← infoExists trees field) then
               withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Yes, a field!") do
               highlight' trees y tactics
-              emitToken' <| fakeToken .unknown "."
+              emitToken' <| fakeToken (.delim none none none) "."
               -- Manually bump the last-seen position so we don't double-print the dot.
               -- The source info for `y` has an erroneous trailing tail pos of `0`,
               -- so we use `tailPos?` since it can't have trailing whitespace anyway
@@ -1892,6 +1893,15 @@ partial def highlight'
           | _ => ("", none)
         emitToken stx i ⟨.wildcard ty tyFmt, x⟩
       else
+      -- Whether the atom is keyword-shaped: ASCII-alphabetic, or `#` followed by a letter.
+      let isKeyword :=
+        match Compat.String.Pos.get? x 0 with
+        | some '#' =>
+          match Compat.String.Pos.get? x ((0 : Compat.String.Pos) + '#') with
+          | some c => c.isAlpha
+          | _ => false
+        | some c => c.isAlpha
+        | _ => false
       match k with
       | .sort docs? =>
         withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Sort") do
@@ -1899,28 +1909,27 @@ partial def highlight'
       | .unknown =>
         -- `identKind` didn't match this to an identifier, so it's not something akin to Mathlib's
         -- `ℕ`; no elaboration info matches its exact span. Classify it lexically:
+        --  * a `·` with no semantic info is a proof-focus bullet — a delimiter (the `·` that *does*
+        --    resolve, an anonymous-function placeholder like `(· + 1)`, keeps its kind below);
         --  * `atomKind` classifies punctuation (separator/bracket/operator), and notably a
         --    bracket-like atom such as `foo[` wins over the keyword heuristic even though it starts
         --    with a letter;
         --  * a remaining alphabetic or `#`-prefixed atom is a `.keyword`.
         match atomKind name occ docs x with
           | .unknown =>
-            let isKeyword :=
-              match Compat.String.Pos.get? x 0 with
-              | some '#' =>
-                match Compat.String.Pos.get? x ((0 : Compat.String.Pos) + '#') with
-                | some c => c.isAlpha
-                | _ => false
-              | some c => c.isAlpha
-              | _ => false
-            if isKeyword then emitToken stx i ⟨.keyword name occ docs, x⟩
+            if !x.isEmpty && x.all (· == '·') then emitToken stx i ⟨.delim name occ docs, x⟩
+            else if isKeyword then emitToken stx i ⟨.keyword name occ docs, x⟩
             else emitToken stx i ⟨.unknown, x⟩
           | k => emitToken stx i ⟨k, x⟩
       | _ =>
-        -- A nullary notation or symbol constant (e.g. `ℕ`, `ℤ`, `ℝ`) whose canonical span is
-        -- exactly this atom resolved span-exact via `identKind`; keep its semantic kind.
-        withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Resolved atom is {repr k}") do
-          emitToken stx i ⟨k, x⟩
+        -- A keyword-shaped atom (e.g. `instance`) can resolve span-exact to a generated declaration
+        -- name — anonymous instances get a synthesized name whose info covers the `instance` token.
+        -- Keep it a `.keyword` rather than rendering it as that constant. A non-keyword atom that
+        -- resolved (Mathlib's `ℕ`, or a `·` placeholder) keeps its semantic kind.
+        if isKeyword then emitToken stx i ⟨.keyword name occ docs, x⟩
+        else
+          withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Resolved atom is {repr k}") do
+            emitToken stx i ⟨k, x⟩
     | stx@(.node _ `Lean.Parser.Command.versoCommentBody _) =>
       if let some endPos := Compat.getTrailingTailPos? stx then
         fillMissingSourceUpTo endPos

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -675,14 +675,12 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
     | Expr.lit (.strVal s) => return some (.str s, none)
     | Expr.mdata _ e =>
       findKind e
-    | other =>
+    | _other =>
       if allowUnknownTyped then
-        runMeta do
-          try
-            let t ← Meta.inferType other >>= instantiateMVars >>= Meta.ppExpr
-            return some (.withType <| toString t, none)
-          catch _ =>
-            return none
+        -- Pretty-print the type, collecting reflowable format data when requested (e.g. a numeral
+        -- of type `Fin 5`). The format is carried in the second projection for the caller to resolve.
+        let (tyStr, prettySig) ← ppVarType
+        if tyStr.isEmpty then return none else return some (.withType tyStr, prettySig)
       else
         return none
 
@@ -944,15 +942,10 @@ def collectMessageBoundariesBetween (startPos endPos : Compat.String.Pos)
 private def peekChar (iter : Compat.String.Iterator) : Option Char :=
   if h : iter.hasNext then some (iter.curr' h) else none
 
-/-- Emits an accumulated whitespace run as text, or as unparsed source when `unparsed` is set. -/
-private def emitTriviaText (unparsed : Bool) (s : String) : HighlightM Unit :=
+/-- Emits an accumulated whitespace run as text. -/
+private def emitTriviaText (s : String) : HighlightM Unit :=
   unless s.isEmpty do
-    modify fun st => { st with
-      output :=
-        if unparsed then
-          Output.addUnparsed st.output s
-        else Output.addText st.output s
-    }
+    modify fun st => { st with output := Output.addText st.output s }
 
 /-- Emits a non-empty trivia token of the given kind. -/
 private def emitTriviaToken (k : Token.Kind) (s : String) : HighlightM Unit :=
@@ -978,9 +971,9 @@ def emitLineComment (start : Compat.String.Iterator) : HighlightM Compat.String.
 
 /--
 Emits a depth-balanced (nesting) block comment, scanning from `iter` (positioned just after the
-opening `/-`). Each opener `/-` and closer `-/` (including nested ones) is emitted as a
-`.commentDelim` token; the text between delimiters is emitted as `.blockComment`. Returns the
-iterator just past the outermost closing `-/` (or at end if unterminated).
+opening `/-`). Only the *outermost* `/-` and `-/` are emitted as `.commentDelim` tokens; everything
+between them — including any nested `/-`…`-/` delimiters — is emitted as a single `.blockComment`
+body token. Returns the iterator just past the outermost closing `-/` (or at end if unterminated).
 -/
 def emitBlockComment (start : Compat.String.Iterator) : HighlightM (Option Compat.String.Iterator) := do
   -- Scan (without emitting) for the depth-balanced closing `-/`, tracking whether the previous
@@ -1026,12 +1019,16 @@ Splits a whitespace-and-comment trivia string into whitespace runs and comment t
 each to the output in source order. Comment delimiters (`--`, `/-`, `-/`) are emitted as
 `.commentDelim` tokens, distinct from the `.lineComment`/`.blockComment` body text. Doc comments are
 real syntax nodes and thus handled elsewhere.
+
+This must only be called on genuine token trivia (leading/trailing whitespace+comments). It is *not*
+used for unparsed source gaps, which are arbitrary un-attributed text: tokenizing comments there
+could falsely split non-comment text (e.g. comment markers appearing inside a string literal).
 -/
-def emitTrivia (s : String) (unparsed : Bool := false) : HighlightM Unit := do
+def emitTrivia (s : String) : HighlightM Unit := do
   -- Fast path: a comment can only contain `-` or `/`, so a string without either is pure
   -- whitespace and is emitted as a single run (matching the previous behavior exactly).
   if !s.any (fun c => c == '-' || c == '/') then
-    emitTriviaText unparsed s
+    emitTriviaText s
     return
   -- `runStart` marks the beginning of the current whitespace run; `iter` scans ahead. When a
   -- comment opener is found, the run `[runStart, iter)` is flushed and the comment is emitted.
@@ -1041,11 +1038,11 @@ def emitTrivia (s : String) (unparsed : Bool := false) : HighlightM Unit := do
     let c := iter.curr' h
     let next := iter.next' h
     if c == '-' && peekChar next == some '-' then
-      emitTriviaText unparsed (runStart.extract iter)
+      emitTriviaText (runStart.extract iter)
       iter := (← emitLineComment next.next)
       runStart := iter
     else if c == '/' && peekChar next == some '-' then
-      emitTriviaText unparsed (runStart.extract iter)
+      emitTriviaText (runStart.extract iter)
       match (← emitBlockComment next.next) with
       | some iter' =>
         iter := iter'
@@ -1056,7 +1053,7 @@ def emitTrivia (s : String) (unparsed : Bool := false) : HighlightM Unit := do
         iter := next
     else
       iter := next
-  emitTriviaText unparsed (runStart.extract iter)
+  emitTriviaText (runStart.extract iter)
 
 /-- Adds to the output any source (if any exists) lying between the last added position and `pos`. -/
 def fillMissingSourceUpTo (pos : Compat.String.Pos) : HighlightM Unit := do
@@ -1071,7 +1068,10 @@ def fillMissingSourceUpTo (pos : Compat.String.Pos) : HighlightM Unit := do
         let endPos := boundaries[i]!
         openUntil <| text.toPosition startPos
         let string := Compat.Substring.mk text.source startPos endPos |>.toString
-        emitTrivia string (unparsed := true)
+        -- Gaps are arbitrary un-attributed source, not guaranteed to be whitespace+comments, so emit
+        -- them verbatim rather than risk mis-tokenizing non-comment text as comments. Comments in
+        -- genuine token trivia are still tokenized via `emitToken`'s `emitTrivia` calls.
+        modify fun st => { st with output := Output.addUnparsed st.output string }
         closeUntil endPos
         setLastPos endPos
 
@@ -1292,6 +1292,21 @@ def identKind
   | .var id tyStr none =>
     return .var id tyStr (← resolveFormatWithInfos kindSig)
   | _ => pure kind
+
+/--
+The inferred type of a literal (e.g. a numeral), as a pretty-printed string and optional reflowable
+format. Unlike `identKind`, this just reads the type of the literal's own elaboration info rather
+than classifying it. A numeral should never be treated as, say, the `OfNat.ofNat` constant.
+-/
+def literalType (trees : Array Lean.Elab.InfoTree) (stx : Syntax) :
+    HighlightM (Option String × Option String) := do
+  for t in trees do
+    for (ci, info) in infoForSyntax t stx do
+      -- `exprKind` (with `allowUnknownTyped`) reports a non-`const`/`var`/`sort`/`str` expression —
+      -- which a numeral's `OfNat.ofNat …`/literal application is — as `.withType <type>`.
+      if let some (.withType ty, prettySig) ← infoKind ci info (allowUnknownTyped := true) then
+        return (some ty, ← resolveFormatWithInfos prettySig)
+  return (none, none)
 
 /-- Returns the format data JSON for `key` from the cache, or computes and caches it. -/
 def renderOrGetFormat (key : Expr) (render : Expr → HighlightM String) : HighlightM (Option String) := do
@@ -1862,12 +1877,8 @@ partial def highlight'
         emitToken stx i ⟨.unknown, c⟩
     | .node _ `num #[.atom i n] | .node _ `scientific #[.atom i n] =>
       withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Numeral") do
-        -- Keep the inferred type (if any) for hover, but emit a dedicated numeric kind.
-        let k ← identKind trees ⟨stx⟩ (allowUnknownTyped := true)
-        let numKind := match k with
-          | .withType t => .num (some t) none
-          | _ => .num none none
-        emitToken stx i ⟨numKind, n⟩
+        let (ty?, tyFmt?) ← literalType trees stx
+        emitToken stx i ⟨.num ty? tyFmt?, n⟩
     | .node _ ``Lean.Parser.Command.docComment #[.atom i1 opener, .atom i2 body] =>
       withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Doc comment") do
       if let .original leading pos ws _ := i1 then

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -86,6 +86,7 @@ def Context.noDefinitions (ctxt : Context) : Context := {ctxt with definitionsPo
 
 partial def Token.Kind.priority : Token.Kind → Nat
   | .var .. => 2
+  | .wildcard .. => 2
   | .str .. => 3
   | .const .. => 5
   | .anonCtor .. => 6
@@ -93,6 +94,7 @@ partial def Token.Kind.priority : Token.Kind → Nat
   | .sort .. => 4
   | .moduleName .. => 4
   | .keyword .. => 3
+  | .delim .. => 3
   | .levelConst .. | .levelVar .. | .levelOp .. => 4
   | .num .. | .char .. => 3
   | .operator .. | .bracket .. | .separator .. => 1
@@ -1876,7 +1878,20 @@ partial def highlight'
         | some (n, _) => findDocString? (← getEnv) n
       let name := lookingAt.map (·.1)
       let occ := lookingAt.map fun (n, pos) => s!"{n}-{pos}"
+      -- A core delimiter (e.g. `:=` or `=>`) is always a `.delim`, regardless of any elaboration
+      -- info that happens to match its span.
+      if isSymbolicKeyword x then
+        emitToken stx i ⟨.delim name occ docs, x⟩
+      else
       let k ← identKind trees ⟨stx⟩
+      -- A wildcard / hole `_` is indicated separately from a variable to allow separate styling.
+      if x == "_" then
+        let (ty, tyFmt) := match k with
+          | .var _ ty tyFmt => (ty, tyFmt)
+          | .withType ty => (ty, none)
+          | _ => ("", none)
+        emitToken stx i ⟨.wildcard ty tyFmt, x⟩
+      else
       match k with
       | .sort docs? =>
         withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Sort") do
@@ -1884,16 +1899,11 @@ partial def highlight'
       | .unknown =>
         -- `identKind` didn't match this to an identifier, so it's not something akin to Mathlib's
         -- `ℕ`; no elaboration info matches its exact span. Classify it lexically:
-        --  * a curated core symbolic keyword (`:=`, `=>`, …) is a `.keyword` — checked first so it
-        --    wins over the operator classification below;
-        --  * otherwise `atomKind` classifies punctuation (separator/bracket/operator), and notably a
+        --  * `atomKind` classifies punctuation (separator/bracket/operator), and notably a
         --    bracket-like atom such as `foo[` wins over the keyword heuristic even though it starts
         --    with a letter;
         --  * a remaining alphabetic or `#`-prefixed atom is a `.keyword`.
-        if isSymbolicKeyword x then
-          emitToken stx i ⟨.keyword name occ docs, x⟩
-        else
-          match atomKind name occ docs x with
+        match atomKind name occ docs x with
           | .unknown =>
             let isKeyword :=
               match Compat.String.Pos.get? x 0 with

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -355,6 +355,24 @@ def Output.add (output : List Output) (hl : Highlighted) : List Output :=
 def Output.addToken (output : List Output) (token : Token) : List Output :=
   Output.add output (.token token)
 
+/--
+Adds a comment token from token *trivia*. Unlike `addToken`, this keeps the token *outside* an
+open tactic region (like `addText` does for whitespace), so a comment in a token's leading trivia
+stays adjacent to its surrounding whitespace rather than being pulled into the tactic content. This
+matters for indented directive comments (`-- ANCHOR:`/`--^ PROOF_STATE:`), whose indentation must
+stay on the same line as the comment for the extractor.
+-/
+def Output.addTriviaToken (output : List Output) (token : Token) : List Output :=
+  match output with
+  | [] => [.seq #[.token token]]
+  | .seq left :: more =>
+    if left.all (·.isEmpty) then
+      Output.addTriviaToken more token
+    else
+      .seq (left.push (.token token)) :: more
+  | .span .. :: _ => .seq #[.token token] :: output
+  | t@(.tactics ..) :: more => t :: Output.addTriviaToken more token
+
 def Output.addUnparsed (output : List Output) (text : String) : List Output :=
   Output.add output (.unparsed text)
 
@@ -947,11 +965,11 @@ private def emitTriviaText (s : String) : HighlightM Unit :=
   unless s.isEmpty do
     modify fun st => { st with output := Output.addText st.output s }
 
-/-- Emits a non-empty trivia token of the given kind. -/
+/-- Emits a non-empty comment token, keeping it outside any open tactic region (see `addTriviaToken`). -/
 private def emitTriviaToken (k : Token.Kind) (s : String) : HighlightM Unit :=
   unless s.isEmpty do
     modify fun st => { st with
-      output := Output.addToken st.output ⟨k, s⟩
+      output := Output.addTriviaToken st.output ⟨k, s⟩
     }
 
 /--

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -643,9 +643,9 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
         pure (sigStr, sig, ci)
     if doCollect then return (sigStr, some (sig, ci)) else return (sigStr, none)
 
-  -- Pretty-print a variable's type. Returns (tyString, sigOrType?) — the second projection is a
-  -- pretty printed type for later use by identKind
-  let ppVarType : m (String × Option (FormatWithInfos × ContextInfo)) := do
+  -- Pretty-print the inferred type of `expr` (a variable, or any expression whose kind is otherwise
+  -- unknown).
+  let ppTermType : m (String × Option (FormatWithInfos × ContextInfo)) := do
     try
       if doCollect then
         let fi ← runMeta <| withOptions (·.set `pp.tagAppFns true) do
@@ -665,7 +665,7 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
       if let some y := (← read).ids[(← Compat.mkRefIdentFVar id)]? then
         Compat.refIdentCase y
           (onFVar := fun x => do
-            let (tyStr, prettySig) ← ppVarType
+            let (tyStr, prettySig) ← ppTermType
             if let some localDecl := lctx.find? x then
               if localDecl.isAuxDecl then
                 let e ← runMeta <| Meta.ppExpr expr
@@ -680,7 +680,7 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
             let docs ← findDocString? (← getEnv) x
             return some (.const x sig docs false none, prettySig))
       else
-        let (tyStr, prettySig) ← ppVarType
+        let (tyStr, prettySig) ← ppTermType
         return some (.var id tyStr none, prettySig)
     | Expr.const name _ =>
       let docs ← findDocString? (← getEnv) name
@@ -697,9 +697,7 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
       findKind e
     | _other =>
       if allowUnknownTyped then
-        -- Pretty-print the type, collecting reflowable format data when requested (e.g. a numeral
-        -- of type `Fin 5`). The format is carried in the second projection for the caller to resolve.
-        let (tyStr, prettySig) ← ppVarType
+        let (tyStr, prettySig) ← ppTermType
         if tyStr.isEmpty then return none else return some (.withType tyStr, prettySig)
       else
         return none

--- a/src/SubVerso/Highlighting/Highlighted.lean
+++ b/src/SubVerso/Highlighting/Highlighted.lean
@@ -72,11 +72,21 @@ where
 inductive Token.Kind where
   | /-- `occurrence` is a unique identifier that unites the various keyword tokens from a given production -/
     keyword (name : Option Name) (occurrence : Option String) (docs : Option String)
+  /--
+  A built-in syntactic delimiter such as `:=`, `=>`, `←`, `@`, `:`, or `|`. Like `keyword` it
+  carries the enclosing production's name, occurrence tag, and docs, but some themes style these
+  differently.
+  -/
+  | delim (name : Option Name) (occurrence : Option String) (docs : Option String)
   | const (name : Name) (signature : String) (docs : Option String) (isDef : Bool)
       (signatureFormat : Option String)
   | anonCtor (name : Name) (signature : String) (docs : Option String)
       (signatureFormat : Option String)
   | var (name : FVarId) (type : String) (typeFormat : Option String)
+  /--
+  A wildcard or hole `_` in term, pattern, or binder position.
+  -/
+  |  wildcard (type : String) (typeFormat : Option String)
   | str (string : String)
   | option (name : Name) (declName : Name) (docs : Option String)
   | docComment
@@ -137,10 +147,12 @@ open Syntax (mkCApp) in
 instance : Quote Token.Kind where
   quote
     | .keyword n occ docs => mkCApp ``keyword #[quote n, quote occ, quote docs]
+    | .delim n occ docs => mkCApp ``delim #[quote n, quote occ, quote docs]
     | .const n sig docs isDef sigFmt => mkCApp ``const #[quote n, quote sig, quote docs, quote isDef, quote sigFmt]
     | .anonCtor n sig docs sigFmt => mkCApp ``anonCtor #[quote n, quote sig, quote docs, quote sigFmt]
     | .option n d docs => mkCApp ``option #[quote n, quote d, quote docs]
     | .var (.mk n) type tyFmt => mkCApp ``var #[mkCApp ``FVarId.mk #[quote n], quote type, quote tyFmt]
+    | .wildcard type tyFmt => mkCApp ``wildcard #[quote type, quote tyFmt]
     | .str s => mkCApp ``str #[quote s]
     | .docComment => mkCApp ``docComment #[]
     | .sort doc? => mkCApp ``sort #[quote doc?]
@@ -175,12 +187,14 @@ The canonical CSS class for a token kind.
 -/
 def Token.Kind.cssClass : Token.Kind → String
   | .var .. => "var"
+  | .wildcard .. => "wildcard"
   | .str .. => "literal string"
   | .sort .. => "sort"
   | .const .. => "const"
   | .option .. => "option"
   | .docComment => "doc-comment"
   | .keyword .. => "keyword"
+  | .delim .. => "built-in delim"
   | .anonCtor .. => "const anon-ctor"
   | .num .. => "literal number"
   | .char .. => "literal char"
@@ -205,6 +219,7 @@ def Token.Kind.binding : Token.Kind → String
   | .var ⟨v⟩ .. => "var-" ++ toString v
   | .option n _ _ => "option-" ++ toString n
   | .keyword _ (some occ) _
+  | .delim _ (some occ) _
   | .operator _ (some occ) _
   | .bracket _ (some occ) _
   | .separator _ (some occ) _ => "kw-occ-" ++ toString occ

--- a/src/SubVerso/Highlighting/Highlighted.lean
+++ b/src/SubVerso/Highlighting/Highlighted.lean
@@ -17,6 +17,17 @@ open Lean
 
 namespace SubVerso.Highlighting
 
+-- `Char` has no `ToJson`/`FromJson` in core, so provide one (as a single-character string) for the
+-- derived `Token.Kind` instances, which carry a decoded `Char` for character literals.
+private instance : ToJson Char where
+  toJson c := toJson c.toString
+
+private instance : FromJson Char where
+  fromJson? j := do
+    let s := (← fromJson? (α := String) j)
+    if s.length = 1 then return Compat.String.Pos.get s 0
+    else .error "expected a single-character string for Char"
+
 deriving instance Repr for Std.Format.FlattenBehavior
 deriving instance Repr for Std.Format
 
@@ -85,6 +96,31 @@ inductive Token.Kind where
   | moduleName (name : Name)
   | /-- The token represents some otherwise-undescribed Expr whose type is known -/
     withType (type : String)
+  | /-- A numeric literal; keeps the optional inferred type (and its format) for hover -/
+    num (type : Option String) (typeFormat : Option String)
+  | /-- A character literal, e.g. `'c'`; carries the decoded character -/
+    char (char : Char)
+  | /-- The body text of a line comment (the part after `--`) -/
+    lineComment
+  | /-- The body text of a block comment (the part between `/-` and `-/`, non-doc) -/
+    blockComment
+  | /-- A comment delimiter: a `--` opener, or a `/-` / `-/` block-comment opener/closer -/
+    commentDelim
+  | /--
+    A symbolic operator atom, such as `+`, `::`, or `>>=`. Like `keyword`, it carries the
+    enclosing notation's name, a per-production occurrence tag, and its docstring.
+    -/
+    operator (name : Option Name) (occurrence : Option String) (docs : Option String)
+  | /--
+    A paired delimiter atom, such as `(` `)` `[` `]` `{` `}` `⟨` or `⟩`. Carries the enclosing
+    notation's name, a per-production occurrence tag, and its docstring.
+    -/
+    bracket (name : Option Name) (occurrence : Option String) (docs : Option String)
+  | /--
+    An item separator atom, such as `,` or `;`. Carries the enclosing notation's name, a
+    per-production occurrence tag, and its docstring.
+    -/
+    separator (name : Option Name) (occurrence : Option String) (docs : Option String)
   | unknown
 deriving Repr, Inhabited, BEq, Hashable, ToJson, FromJson
 
@@ -121,6 +157,14 @@ instance : Quote Token.Kind where
     | .moduleName m => mkCApp ``moduleName #[quote m]
     | .levelOp n => mkCApp ``levelOp #[quote n]
     | .withType t => mkCApp ``withType #[quote t]
+    | .num t tyFmt => mkCApp ``num #[quote t, quote tyFmt]
+    | .char c => mkCApp ``char #[quote c]
+    | .lineComment => mkCApp ``lineComment #[]
+    | .blockComment => mkCApp ``blockComment #[]
+    | .commentDelim => mkCApp ``commentDelim #[]
+    | .operator n occ docs => mkCApp ``operator #[quote n, quote occ, quote docs]
+    | .bracket n occ docs => mkCApp ``bracket #[quote n, quote occ, quote docs]
+    | .separator n occ docs => mkCApp ``separator #[quote n, quote occ, quote docs]
     | .unknown => mkCApp ``unknown #[]
 
 structure Token where
@@ -145,7 +189,15 @@ def Token.Kind.cssClass : Token.Kind → String
   | .option .. => "option"
   | .docComment => "doc-comment"
   | .keyword .. => "keyword"
-  | .anonCtor .. => "unknown"
+  | .anonCtor .. => "const anon-ctor"
+  | .num .. => "literal number"
+  | .char .. => "literal char"
+  | .lineComment => "comment line"
+  | .blockComment => "comment block"
+  | .commentDelim => "comment delimiter"
+  | .operator .. => "punctuation operator"
+  | .bracket .. => "punctuation bracket"
+  | .separator .. => "punctuation separator"
   | .unknown => "unknown"
   | .withType .. => "typed"
   | .levelConst .. => "level-const"
@@ -160,7 +212,10 @@ def Token.Kind.binding : Token.Kind → String
   | .const n .. | .anonCtor n .. => "const-" ++ toString n
   | .var ⟨v⟩ .. => "var-" ++ toString v
   | .option n _ _ => "option-" ++ toString n
-  | .keyword _ (some occ) _ => "kw-occ-" ++ toString occ
+  | .keyword _ (some occ) _
+  | .operator _ (some occ) _
+  | .bracket _ (some occ) _
+  | .separator _ (some occ) _ => "kw-occ-" ++ toString occ
   | .sort (some d) => s!"sort-{hash d}"
   | .levelVar x => s!"level-var-{x}"
   | .levelConst i => s!"level-const-{i}"

--- a/src/SubVerso/Highlighting/Highlighted.lean
+++ b/src/SubVerso/Highlighting/Highlighted.lean
@@ -17,16 +17,8 @@ open Lean
 
 namespace SubVerso.Highlighting
 
--- `Char` has no `ToJson`/`FromJson` in core, so provide one (as a single-character string) for the
--- derived `Token.Kind` instances, which carry a decoded `Char` for character literals.
-private instance : ToJson Char where
-  toJson c := toJson c.toString
-
-private instance : FromJson Char where
-  fromJson? j := do
-    let s := (← fromJson? (α := String) j)
-    if s.length = 1 then return Compat.String.Pos.get s 0
-    else .error "expected a single-character string for Char"
+-- The `Char` instances required by `Token.Kind`'s derived `ToJson`/`FromJson`/`Hashable` and `Quote`
+-- (for the decoded `Char` of character literals) are provided, where core lacks them, by `Compat`.
 
 deriving instance Repr for Std.Format.FlattenBehavior
 deriving instance Repr for Std.Format


### PR DESCRIPTION
Adds a set of lexically-distinguished tokens that make it easier to work with off-the-shelf color themes, including:
 * Number literals
 * Various brackets
 * Operators
 * Separators
 * Comments