### PR TITLE
chore: attempt to make CI more reliable

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -24,7 +24,7 @@ jobs:
         platform:
           - os: nscloud-ubuntu-22.04-amd64-8x16
             installer: |
-              curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y
+              curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
         # Mac runners are rare and expensive, so spot-check that the
         # subprocess support seems OK but be less thorough
         include:
@@ -32,7 +32,7 @@ jobs:
             platform:
               os: macos-latest
               installer: |
-                curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y
+                curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
 
     name: Build and test (${{ matrix.platform.os }}, ${{ matrix.platform.installer}}, ${{ matrix.toolchain}})
     uses: "./.github/workflows/run-ci.yml"

--- a/.github/workflows/ci-pre-module.yml
+++ b/.github/workflows/ci-pre-module.yml
@@ -43,7 +43,7 @@ jobs:
         platform:
           - os: nscloud-ubuntu-22.04-amd64-8x16
             installer: |
-              curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y
+              curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
         # Mac runners are rare and expensive, so spot-check that the
         # subprocess support seems OK but be less thorough
         include:
@@ -51,12 +51,12 @@ jobs:
             platform:
               os: macos-latest
               installer: |
-                curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y
+                curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
           - toolchain: "4.9.1"
             platform:
               os: macos-latest
               installer: |
-                curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y
+                curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
           - toolchain: "4.8.0"
             platform:
               os: macos-latest

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -60,7 +60,7 @@ jobs:
           timeout_minutes: 15
           max_attempts: 3
           retry_wait_seconds: 15
-          command: elan toolchain install leanprover/lean4:${{ inputs.toolchain }}
+          command: elan run --install leanprover/lean4:${{ inputs.toolchain }} lean --version
 
       - name: Install demo Lean toolchain
         uses: nick-fields/retry@v3
@@ -68,7 +68,7 @@ jobs:
           timeout_minutes: 15
           max_attempts: 3
           retry_wait_seconds: 15
-          command: elan toolchain install leanprover/lean4:v4.3.0
+          command: elan run --install leanprover/lean4:v4.3.0 lean --version
 
       - name: Install TOML demo Lean toolchain
         uses: nick-fields/retry@v3
@@ -76,7 +76,7 @@ jobs:
           timeout_minutes: 15
           max_attempts: 3
           retry_wait_seconds: 15
-          command: elan toolchain install leanprover/lean4:v4.8.0
+          command: elan run --install leanprover/lean4:v4.8.0 lean --version
 
       - name: Install compatibility test Lean toolchain
         uses: nick-fields/retry@v3
@@ -84,7 +84,7 @@ jobs:
           timeout_minutes: 15
           max_attempts: 3
           retry_wait_seconds: 15
-          command: elan toolchain install leanprover/lean4:4.10.0
+          command: elan run --install leanprover/lean4:4.10.0 lean --version
 
       - name: Lean version
         run: |

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -62,6 +62,30 @@ jobs:
           retry_wait_seconds: 15
           command: elan toolchain install leanprover/lean4:${{ inputs.toolchain }}
 
+      - name: Install demo Lean toolchain
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: elan toolchain install leanprover/lean4:v4.3.0
+
+      - name: Install TOML demo Lean toolchain
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: elan toolchain install leanprover/lean4:v4.8.0
+
+      - name: Install compatibility test Lean toolchain
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: elan toolchain install leanprover/lean4:4.10.0
+
       - name: Lean version
         run: |
           lean --version

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
         default: |
-          curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y
+          curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
 
 
 jobs:
@@ -53,6 +53,14 @@ jobs:
       - name: Select Lean version
         run: |
           echo "leanprover/lean4:${{ inputs.toolchain }}" > lean-toolchain
+
+      - name: Install Lean toolchain
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 15
+          command: elan toolchain install leanprover/lean4:${{ inputs.toolchain }}
 
       - name: Lean version
         run: |


### PR DESCRIPTION
Many runs have some random download failure from GitHub, and this is increasing. This PR retries on failure, and also avoids downloading the stable toolchain each time (which is another step that could fail).