### PR TITLE
fix: show proof states for compound tactics

### DIFF
--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -758,6 +758,24 @@ def assertStateTree (src : String) (expected : List (Nat × String × List Strin
   unless tree == expected do
     throwError m!"proof-state tree =\n{repr tree}\nexpected\n{repr expected}"
 
+open Lean Elab Command in
+/--
+Asserts the nested proof-state tree of `src` (highlighted module-style) equals `expected`, after
+dropping nested `by`-token regions (those at depth > 0 whose code is `"by"`).
+
+Whether a macro tactic's embedded `by` carries a state is toolchain-dependent: some Lean versions
+record it with the subproof's goal (so it is shown), later ones with the *enclosing* goal (so
+`Code.conclusionDuplicatesEnclosing` drops it as redundant). That nested-`by` state is therefore not
+a guaranteed output, so this asserts only the stable structure — the whole-tactic region and the real
+subproof steps.
+
+For tactics whose nested `by` state *is* stable, use `assertStateTree`, which compares exactly.
+-/
+def assertStateTreeIgnoringNestedBy (src : String) (expected : List (Nat × String × List String)) : CommandElabM Unit := do
+  let tree := (← highlightModuleStyle src).stateTree.toList.filter fun (depth, code, _) => !(depth > 0 && code == "by")
+  unless tree == expected do
+    throwError m!"proof-state tree (ignoring nested `by`) =\n{repr tree}\nexpected\n{repr expected}"
+
 -- `rw`: the closing `rfl` solves the goal, so the outer `rw [...]` region shows the empty (solved)
 -- state, with the three rewrite steps nested at depth 1. Each step's region spans the elaborator's
 -- recorded node — the rule together with its trailing separator — so the non-final steps include the
@@ -792,10 +810,10 @@ open Lean Elab Command in
      (1, "h1,", ["b = d"]), (1, "h2,", ["c = d"]), (1, "h3", ["d = d"])]
 
 -- `replace h : T := by …` is `have`'s sibling (it rebinds `h`): same macro shape, so the whole
--- `replace` shows the state after it and the macro-mangled nested `by` state is dropped, leaving the
--- subproof's real steps.
+-- `replace` shows the state after it, with the subproof's real steps nested inside. (Asserted modulo
+-- the nested `by` token, which is toolchain-dependent — see the `have` tests below.)
 open Lean Elab Command in
-#eval assertStateTree
+#eval assertStateTreeIgnoringNestedBy
   "example (h : Nat) : True := by\n  replace h : Int := by exact 0\n  trivial"
   [(0, "by", ["True"]),
    (0, "replace h : Int := by exact 0", ["True"]),
@@ -839,20 +857,19 @@ open Lean Elab Command in
    (0, "trivial", [])]
 
 -- `have … := by …` is a single tactic, so the whole `have` gets a region showing the state *after*
--- it (the goal with `h` added), with the subproof's steps nested inside at depth 1. The subproof's
--- own `by` token shows *no* state: `have` is a macro, and its embedded `by` is recorded with the
--- enclosing goal rather than the subproof's, so that initial state would just repeat the enclosing
--- conclusion — it is dropped by `conclusionsDuplicateOpen`, while the real steps survive.
+-- it (the goal with `h` added), with the subproof's steps nested inside at depth 1. (Asserted modulo
+-- the nested `by` token: `have` is a macro, and whether its embedded `by` carries a state varies by
+-- toolchain.)
 open Lean Elab Command in
-#eval assertStateTree
+#eval assertStateTreeIgnoringNestedBy
   "example : True := by\n  have h : 2 = 2 := by rfl\n  trivial"
   [(0, "by", ["True"]),
    (0, "have h : 2 = 2 := by rfl", ["True"]),
      (1, "rfl", []),
    (0, "trivial", [])]
--- A multi-step subproof keeps every nested step (and still drops the spurious nested-`by` state).
+-- A multi-step subproof keeps every nested step.
 open Lean Elab Command in
-#eval assertStateTree
+#eval assertStateTreeIgnoringNestedBy
   "example : True := by\n  have h : 1 = 1 ∧ 2 = 2 := by\n    constructor\n    · rfl\n    · rfl\n  trivial"
   [(0, "by", ["True"]),
    (0, "have h : 1 = 1 ∧ 2 = 2 := by\n    constructor\n    · rfl\n    · rfl", ["True"]),

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -751,9 +751,28 @@ partial def Highlighted.stateTree (hl : Highlighted) (depth : Nat := 0) : Array 
   out
 end SubVerso.Highlighting
 
+-- Some newer tactic syntax — `obtain … : T := by …`, `replace … : T := by …` — doesn't exist on
+-- older toolchains.
 open Lean Elab Command in
-/-- Asserts the nested proof-state tree of `src` (highlighted module-style) equals `expected`. -/
-def assertStateTree (src : String) (expected : List (Nat × String × List String)) : CommandElabM Unit := do
+#eval show CommandElabM Unit from do
+  let env ← getEnv
+  let hasObtain :=
+    (Parser.runParserCategory env `tactic "obtain x : True := by trivial").isOk
+  elabCommand (← `(def$(mkIdent `hasObtain) : Bool := $(quote hasObtain)))
+
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  let env ← getEnv
+  let hasReplace :=
+    (Parser.runParserCategory env `tactic "replace x : True := by trivial").isOk
+  elabCommand (← `(def$(mkIdent `hasReplace) : Bool := $(quote hasReplace)))
+
+open Lean Elab Command in
+/-- Asserts the nested proof-state tree of `src` (highlighted module-style) equals `expected`. Does
+nothing when `skip` is true — used to skip tactics whose syntax doesn't parse on this toolchain. -/
+def assertStateTree (src : String) (expected : List (Nat × String × List String))
+    (skip : Bool := false) : CommandElabM Unit := do
+  if skip then return
   let tree := (← highlightModuleStyle src).stateTree.toList
   unless tree == expected do
     throwError m!"proof-state tree =\n{repr tree}\nexpected\n{repr expected}"
@@ -770,8 +789,12 @@ a guaranteed output, so this asserts only the stable structure — the whole-tac
 subproof steps.
 
 For tactics whose nested `by` state *is* stable, use `assertStateTree`, which compares exactly.
+
+Does nothing when `skip` is true — used to skip tactics whose syntax doesn't parse on this toolchain.
 -/
-def assertStateTreeIgnoringNestedBy (src : String) (expected : List (Nat × String × List String)) : CommandElabM Unit := do
+def assertStateTreeIgnoringNestedBy (src : String) (expected : List (Nat × String × List String))
+    (skip : Bool := false) : CommandElabM Unit := do
+  if skip then return
   let tree := (← highlightModuleStyle src).stateTree.toList.filter fun (depth, code, _) => !(depth > 0 && code == "by")
   unless tree == expected do
     throwError m!"proof-state tree (ignoring nested `by`) =\n{repr tree}\nexpected\n{repr expected}"
@@ -819,6 +842,7 @@ open Lean Elab Command in
    (0, "replace h : Int := by exact 0", ["True"]),
      (1, "exact 0", []),
    (0, "trivial", [])]
+  (skip := !hasReplace)
 
 -- `suffices h : T by …` is one tactic: the whole `suffices` shows the state *after* it — the new
 -- (sufficient) goal `T` — and the nested `by …` (which discharges the *original* goal from `h`) keeps
@@ -892,6 +916,7 @@ open Lean Elab Command in
      (1, "by", ["∃ k, k = 0"]),
      (1, "exact ⟨0, rfl⟩", []),
    (0, "trivial", [])]
+  (skip := !hasObtain)
 open Lean Elab Command in
 #eval assertStateTree
   "example : True := by\n  obtain ⟨k, hk⟩ := id (α := ∃ k : Nat, k = 0) (by exact ⟨0, rfl⟩)\n  trivial"
@@ -900,6 +925,7 @@ open Lean Elab Command in
      (1, "by", ["∃ k, k = 0"]),
      (1, "exact ⟨0, rfl⟩", []),
    (0, "trivial", [])]
+  (skip := !hasObtain)
 
 -- Comments that look like directives but are not directive *lines* must keep their token styling:
 -- a block comment and an ordinary full-line comment, both containing `ANCHOR:`.

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -439,33 +439,6 @@ elab "#assertHasKind" inp:str kind:str : command => do
 
 open Lean Elab Command in
 /--
-`#assertTacticKind inp kind` parses `inp` as a tactic and checks its syntax kind is `kind`.
-
-The highlighter special-cases certain tactics (`have`, `obtain`, …) by their syntax kind. The kinds
-themselves are referenced with ``…`` in `findTactics`, so a *missing* name is caught at compile time;
-these assertions cover the other half — that the (sometimes auto-generated) name still denotes the
-tactic of interest. If a toolchain makes `have`/`obtain` parse to a different kind, this fails in CI
-for that toolchain, pointing at the kind in `findTactics` that needs updating.
--/
-elab "#assertTacticKind" inp:str kind:str : command => do
-  match Parser.runParserCategory (← getEnv) `tactic inp.getString with
-  | .error e => throwError m!"failed to parse tactic {repr inp.getString}: {e}"
-  | .ok stx =>
-    unless stx.getKind == kind.getString.toName do
-      throwError m!"tactic {repr inp.getString} parses to kind {stx.getKind}, expected \
-        {kind.getString}; update the highlighter's special-cased kind for this Lean toolchain"
-
--- The highlighter attaches whole-tactic proof-state regions to these tactics by keying on these
--- exact syntax kinds (see `findTactics`). These guard that the names still denote those tactics
--- (and the `assertStateTree` tests below guard the resulting behavior).
-#assertTacticKind "have h : Nat := by exact 0" "Lean.Parser.Tactic.tacticHave__"
-#assertTacticKind "obtain ⟨a, b⟩ := h" "Lean.Parser.Tactic.obtain"
-#assertTacticKind "let x : Nat := by exact 0" "Lean.Parser.Tactic.tacticLet__"
-#assertTacticKind "suffices h : Nat by trivial" "Lean.Parser.Tactic.tacticSuffices_"
-#assertTacticKind "replace h : Nat := by exact 0" "Lean.Parser.Tactic.replace"
-
-open Lean Elab Command in
-/--
 `#assertAnchor inp name expected` highlights `inp` (so comments are tokenized), runs the anchor
 extractor, and checks that the anchor `name` exists and its code equals `expected` exactly
 (untrimmed — the surrounding whitespace is part of what these tests protect). This guards that

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -439,6 +439,33 @@ elab "#assertHasKind" inp:str kind:str : command => do
 
 open Lean Elab Command in
 /--
+`#assertTacticKind inp kind` parses `inp` as a tactic and checks its syntax kind is `kind`.
+
+The highlighter special-cases certain tactics (`have`, `obtain`, …) by their syntax kind. The kinds
+themselves are referenced with ``…`` in `findTactics`, so a *missing* name is caught at compile time;
+these assertions cover the other half — that the (sometimes auto-generated) name still denotes the
+tactic of interest. If a toolchain makes `have`/`obtain` parse to a different kind, this fails in CI
+for that toolchain, pointing at the kind in `findTactics` that needs updating.
+-/
+elab "#assertTacticKind" inp:str kind:str : command => do
+  match Parser.runParserCategory (← getEnv) `tactic inp.getString with
+  | .error e => throwError m!"failed to parse tactic {repr inp.getString}: {e}"
+  | .ok stx =>
+    unless stx.getKind == kind.getString.toName do
+      throwError m!"tactic {repr inp.getString} parses to kind {stx.getKind}, expected \
+        {kind.getString}; update the highlighter's special-cased kind for this Lean toolchain"
+
+-- The highlighter attaches whole-tactic proof-state regions to these tactics by keying on these
+-- exact syntax kinds (see `findTactics`). These guard that the names still denote those tactics
+-- (and the `assertStateTree` tests below guard the resulting behavior).
+#assertTacticKind "have h : Nat := by exact 0" "Lean.Parser.Tactic.tacticHave__"
+#assertTacticKind "obtain ⟨a, b⟩ := h" "Lean.Parser.Tactic.obtain"
+#assertTacticKind "let x : Nat := by exact 0" "Lean.Parser.Tactic.tacticLet__"
+#assertTacticKind "suffices h : Nat by trivial" "Lean.Parser.Tactic.tacticSuffices_"
+#assertTacticKind "replace h : Nat := by exact 0" "Lean.Parser.Tactic.replace"
+
+open Lean Elab Command in
+/--
 `#assertAnchor inp name expected` highlights `inp` (so comments are tokenized), runs the anchor
 extractor, and checks that the anchor `name` exists and its code equals `expected` exactly
 (untrimmed — the surrounding whitespace is part of what these tests protect). This guards that
@@ -790,6 +817,99 @@ open Lean Elab Command in
    (0, "intro h1 h2 h3", ["a = d"]),
    (0, "rw [h1, h2, h3]", []),
      (1, "h1,", ["b = d"]), (1, "h2,", ["c = d"]), (1, "h3", ["d = d"])]
+
+-- `replace h : T := by …` is `have`'s sibling (it rebinds `h`): same macro shape, so the whole
+-- `replace` shows the state after it and the macro-mangled nested `by` state is dropped, leaving the
+-- subproof's real steps.
+open Lean Elab Command in
+#eval assertStateTree
+  "example (h : Nat) : True := by\n  replace h : Int := by exact 0\n  trivial"
+  [(0, "by", ["True"]),
+   (0, "replace h : Int := by exact 0", ["True"]),
+     (1, "exact 0", []),
+   (0, "trivial", [])]
+
+-- `suffices h : T by …` is one tactic: the whole `suffices` shows the state *after* it — the new
+-- (sufficient) goal `T` — and the nested `by …` (which discharges the *original* goal from `h`) keeps
+-- its own state, since it differs from the `suffices` region's conclusion and isn't shadowed by an
+-- open enclosing region of the same conclusion.
+open Lean Elab Command in
+#eval assertStateTree
+  "example : True := by\n  suffices h : Nat by trivial\n  exact 0"
+  [(0, "by", ["True"]),
+   (0, "suffices h : Nat by trivial", ["Nat"]),
+     (1, "by", ["True"]),
+     (1, "trivial", []),
+   (0, "exact 0", [])]
+
+-- `let … := by …`, like `have`, is one tactic, so the whole `let` shows the state *after* it (the
+-- goal with `x` bound). Unlike `have`, `let`'s embedded `by` is *not* macro-mangled — its tacticSeq
+-- is recorded with the subproof's own goal — so the nested `by` keeps its (correct) state, since it
+-- differs from the enclosing conclusion and `conclusionsDuplicateOpen` leaves it alone.
+open Lean Elab Command in
+#eval assertStateTree
+  "example : True := by\n  let x : Nat := by exact 0\n  trivial"
+  [(0, "by", ["True"]),
+   (0, "let x : Nat := by exact 0", ["True"]),
+     (1, "by", ["Nat"]),
+     (1, "exact 0", []),
+   (0, "trivial", [])]
+open Lean Elab Command in
+#eval assertStateTree
+  "example : True := by\n  let x : Nat × Nat := by\n    refine ⟨?_, ?_⟩\n    · exact 0\n    · exact 1\n  trivial"
+  [(0, "by", ["True"]),
+   (0, "let x : Nat × Nat := by\n    refine ⟨?_, ?_⟩\n    · exact 0\n    · exact 1", ["True"]),
+     (1, "by", ["Nat × Nat"]),
+     (1, "refine ⟨?_, ?_⟩", ["Nat", "Nat"]),
+     (1, "·", ["Nat"]), (1, "exact 0", []),
+     (1, "·", ["Nat"]), (1, "exact 1", []),
+   (0, "trivial", [])]
+
+-- `have … := by …` is a single tactic, so the whole `have` gets a region showing the state *after*
+-- it (the goal with `h` added), with the subproof's steps nested inside at depth 1. The subproof's
+-- own `by` token shows *no* state: `have` is a macro, and its embedded `by` is recorded with the
+-- enclosing goal rather than the subproof's, so that initial state would just repeat the enclosing
+-- conclusion — it is dropped by `conclusionsDuplicateOpen`, while the real steps survive.
+open Lean Elab Command in
+#eval assertStateTree
+  "example : True := by\n  have h : 2 = 2 := by rfl\n  trivial"
+  [(0, "by", ["True"]),
+   (0, "have h : 2 = 2 := by rfl", ["True"]),
+     (1, "rfl", []),
+   (0, "trivial", [])]
+-- A multi-step subproof keeps every nested step (and still drops the spurious nested-`by` state).
+open Lean Elab Command in
+#eval assertStateTree
+  "example : True := by\n  have h : 1 = 1 ∧ 2 = 2 := by\n    constructor\n    · rfl\n    · rfl\n  trivial"
+  [(0, "by", ["True"]),
+   (0, "have h : 1 = 1 ∧ 2 = 2 := by\n    constructor\n    · rfl\n    · rfl", ["True"]),
+     (1, "constructor", ["1 = 1", "2 = 2"]),
+     (1, "·", ["1 = 1"]), (1, "rfl", []),
+     (1, "·", ["2 = 2"]), (1, "rfl", []),
+   (0, "trivial", [])]
+
+-- An `obtain` that discharges its goal with a nested `by` is a single tactic, so the whole
+-- `obtain … := …` gets a region showing the state *after* the destructuring, with the nested `by`
+-- proof's states nested inside at depth 1 (like `rw`). (Regression guard: previously the whole
+-- `obtain` region was dropped because `childHasTactics` counted the nested `by`'s tactic info,
+-- leaving only the flat nested `by` states and no clickable `obtain` region.) Both the `:= by …`
+-- form and the `:= f … (by …)` argument form are covered.
+open Lean Elab Command in
+#eval assertStateTree
+  "example : True := by\n  obtain ⟨k, hk⟩ : ∃ k : Nat, k = 0 := by exact ⟨0, rfl⟩\n  trivial"
+  [(0, "by", ["True"]),
+   (0, "obtain ⟨k, hk⟩ : ∃ k : Nat, k = 0 := by exact ⟨0, rfl⟩", ["True"]),
+     (1, "by", ["∃ k, k = 0"]),
+     (1, "exact ⟨0, rfl⟩", []),
+   (0, "trivial", [])]
+open Lean Elab Command in
+#eval assertStateTree
+  "example : True := by\n  obtain ⟨k, hk⟩ := id (α := ∃ k : Nat, k = 0) (by exact ⟨0, rfl⟩)\n  trivial"
+  [(0, "by", ["True"]),
+   (0, "obtain ⟨k, hk⟩ := id (α := ∃ k : Nat, k = 0) (by exact ⟨0, rfl⟩)", ["True"]),
+     (1, "by", ["∃ k, k = 0"]),
+     (1, "exact ⟨0, rfl⟩", []),
+   (0, "trivial", [])]
 
 -- Comments that look like directives but are not directive *lines* must keep their token styling:
 -- a block comment and an ordinary full-line comment, both containing `ANCHOR:`.

--- a/src/SubVerso/Compat.lean
+++ b/src/SubVerso/Compat.lean
@@ -780,6 +780,42 @@ elab_rules : command
       elabCommand (← `(open $ns:ident hiding $xs*))
 
 
+-- The highlighter special-cases certain tactics by their syntax *kind*, but several of those kinds
+-- are auto-generated (`tacticHave__`, `tacticLet__`, `tacticSuffices_`, …) and named differently
+-- across Lean versions. The names can be found by parsing a representative example of each tactic
+-- and reading off its actual kind. A sample that doesn't parse (the tactic is absent in this
+-- version) is dropped, so the feature degrades gracefully rather than failing to build.
+open Lean Elab Command in
+/-- Elaborates `def <name> : List Name := …`, the kinds that `samples` parse to (as tactics) on this
+toolchain, dropping any sample that doesn't parse. -/
+def elabTacticKinds (name : Name) (samples : List String) : CommandElabM Unit := do
+  let env ← getEnv
+  let kinds := samples.filterMap fun s =>
+    match Parser.runParserCategory env `tactic s with
+    | .ok stx => some stx.getKind
+    | .error _ => none
+  let elems : Array Term := kinds.toArray.map (quote ·)
+  elabCommand (← `(def $(mkIdent name) : List Lean.Name := [$elems,*]))
+
+-- `wholeTacticStateKinds`: tactic kinds whose whole-invocation proof state should be shown even
+-- though a nested `by` makes them non-leaves (`simp`, `rw`/`rewrite`, `intro`/`intros`, `obtain`,
+-- `have`, `let`, `suffices`, `replace`). Derived per toolchain — see `elabTacticKinds`.
+open Lean Elab Command in
+#eval show CommandElabM Unit from
+  elabTacticKinds `wholeTacticStateKinds
+    ["simp", "rw [h]", "rewrite [h]", "intro x", "intros",
+     "obtain ⟨a, b⟩ := h", "have h : Nat := by exact 0", "let x : Nat := by exact 0",
+     "suffices h : Nat by trivial", "replace h : Nat := by exact 0"]
+
+-- `keepNestedStateKinds`: tactic kinds whose region is *not* a leaf — their nested states (rewrite
+-- rules, or a nested `by` subproof) must keep being searched for after the whole-tactic region
+-- opens. Derived per toolchain.
+open Lean Elab Command in
+#eval show CommandElabM Unit from
+  elabTacticKinds `keepNestedStateKinds
+    ["rw [h]", "rewrite [h]", "obtain ⟨a, b⟩ := h", "have h : Nat := by exact 0",
+     "let x : Nat := by exact 0", "suffices h : Nat by trivial", "replace h : Nat := by exact 0"]
+
 namespace Frontend
 
 open Lean.Elab.Frontend

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -1535,18 +1535,7 @@ partial def rwRuleGoals
   return none
 
 /-- Tactics which should show inner tactic scripts' states as well as the full final state -/
-def compoundTacticKinds := [
-  ``Lean.Parser.Tactic.simp,
-  ``Lean.Parser.Tactic.rwSeq,
-  ``Lean.Parser.Tactic.rewriteSeq,
-  ``Lean.Parser.Tactic.intro,
-  ``Lean.Parser.Tactic.intros,
-  ``Lean.Parser.Tactic.obtain,
-  ``Lean.Parser.Tactic.tacticHave__,
-  ``Lean.Parser.Tactic.tacticLet__,
-  ``Lean.Parser.Tactic.tacticSuffices_,
-  ``Lean.Parser.Tactic.replace
-]
+def compoundTacticKinds := Compat.wholeTacticStateKinds
 
 partial def findTactics
     (trees : Array Lean.Elab.InfoTree) -- TODO: use the table instead of these
@@ -1911,15 +1900,7 @@ def atomKind (name : Option Name) (occ : Option String) (docs : Option String) (
     .operator name occ docs
   else .unknown
 
-def nestedTacticKinds := [
-  ``Lean.Parser.Tactic.rwSeq,
-  ``Lean.Parser.Tactic.rewriteSeq,
-  ``Lean.Parser.Tactic.obtain,
-  ``Lean.Parser.Tactic.tacticHave__,
-  ``Lean.Parser.Tactic.tacticLet__,
-  ``Lean.Parser.Tactic.tacticSuffices_,
-  ``Lean.Parser.Tactic.replace
-]
+def nestedTacticKinds := Compat.keepNestedStateKinds
 
 partial def highlight'
     (trees : Array Lean.Elab.InfoTree)

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -411,6 +411,18 @@ def Output.tailDuplicatesOpen
     | .tactics info' _ endPos' => endPos == endPos' && info == info'
     | _ => false
 
+/--
+Whether the closest enclosing tactic region shows goals with the same conclusions as `info`. Used to
+drop a nested `by` token's initial state when it merely repeats the conclusion already shown by the
+tactic that immediately encloses it. This happens for macro tactics such as `have h := by …`, whose
+embedded `by` is recorded with the enclosing goal rather than the subproof's.
+-/
+def Output.conclusionDuplicatesEnclosing
+    (output : List Output) (info : Array (Highlighted.Goal Highlighted)) : Bool :=
+  match output.find? (· matches .tactics ..) with
+  | some (.tactics info' _ _) => info'.map (·.conclusion) == info.map (·.conclusion)
+  | _ => false
+
 def Output.closeSpan (output : List Output) : List Output :=
   let rec go (acc : Highlighted) : List Output → List Output
     | [] => [.seq #[acc]]
@@ -1522,6 +1534,20 @@ partial def rwRuleGoals
               return some (← tacticInfoGoals ci ti regionStart regionEnd (text.toPosition regionEnd) (before := false))
   return none
 
+/-- Tactics which should show inner tactic scripts' states as well as the full final state -/
+def compoundTacticKinds := [
+  ``Lean.Parser.Tactic.simp,
+  ``Lean.Parser.Tactic.rwSeq,
+  ``Lean.Parser.Tactic.rewriteSeq,
+  ``Lean.Parser.Tactic.intro,
+  ``Lean.Parser.Tactic.intros,
+  ``Lean.Parser.Tactic.obtain,
+  ``Lean.Parser.Tactic.tacticHave__,
+  ``Lean.Parser.Tactic.tacticLet__,
+  ``Lean.Parser.Tactic.tacticSuffices_,
+  ``Lean.Parser.Tactic.replace
+]
+
 partial def findTactics
     (trees : Array Lean.Elab.InfoTree) -- TODO: use the table instead of these
     (stx : Syntax)
@@ -1550,6 +1576,14 @@ partial def findTactics
           | `(Lean.Parser.Term.byTactic'| by%$tk $tactics) =>
             if tk == stx then
               let ts ← findTactics' tactics startPos endPos endPosition (before := true)
+              -- Macro tactics that embed a `by` (e.g. `have h := by …`) record the byTactic's
+              -- tacticSeq with the *enclosing* goal as its `goalsBefore`, so the `by` token here
+              -- would be labelled with the surrounding state rather than the subproof's. Such an
+              -- initial state just duplicates the state already shown by the enclosing region, so
+              -- drop it: the nested `by` carries no state, but the subproof's own steps still do.
+              if let some (goals, _) := ts then
+                if Output.conclusionDuplicatesEnclosing (← get).output goals then
+                  return none
               return ts
           | _ => continue
 
@@ -1584,7 +1618,10 @@ partial def findTactics
   --   shows the state after all the intros. Otherwise the "most specific span" rule would put the
   --   state on the last binder alone (and lose the first binder, whose info is bundled with the
   --   keyword).
-  if stx.getKind ∉ [``Lean.Parser.Tactic.simp, ``Lean.Parser.Tactic.rwSeq, ``Lean.Parser.Tactic.rewriteSeq, ``Lean.Parser.Tactic.intro, ``Lean.Parser.Tactic.intros] then
+  -- * `obtain`/`have`/`let`/`suffices`/`replace` are single tactics; their nested `by` would
+  --   otherwise suppress the whole-tactic state, so they show the state *after* the tactic (with the
+  --   subproof's steps nested inside).
+  if stx.getKind ∉ compoundTacticKinds then
     if ← childHasTactics stx then return none
 
   if stx.getKind == ``Lean.Parser.Tactic.rwRule then
@@ -1874,6 +1911,16 @@ def atomKind (name : Option Name) (occ : Option String) (docs : Option String) (
     .operator name occ docs
   else .unknown
 
+def nestedTacticKinds := [
+  ``Lean.Parser.Tactic.rwSeq,
+  ``Lean.Parser.Tactic.rewriteSeq,
+  ``Lean.Parser.Tactic.obtain,
+  ``Lean.Parser.Tactic.tacticHave__,
+  ``Lean.Parser.Tactic.tacticLet__,
+  ``Lean.Parser.Tactic.tacticSuffices_,
+  ``Lean.Parser.Tactic.replace
+]
+
 partial def highlight'
     (trees : Array Lean.Elab.InfoTree)
     (stx : Syntax)
@@ -1888,10 +1935,12 @@ partial def highlight'
       -- closing `]` of a `rw`, nested in a tactic region with the same final state).
       unless Output.tailDuplicatesOpen (← get).output tacticInfo endPos do
         HighlightM.openTactic tacticInfo startPos endPos position
-        -- Tactic regions are normally leaves, so disable further search in the subtree. The exception
-        -- is `rw`/`rewrite`: their whole-invocation region is *not* a leaf — each rewrite rule nests
-        -- its own intermediate state inside it — so keep searching their subterms.
-        unless stx.getKind ∈ [``Lean.Parser.Tactic.rwSeq, ``Lean.Parser.Tactic.rewriteSeq] do
+        -- Tactic regions are normally leaves, so disable further search in the subtree. The
+        -- exceptions are not leaves and keep their nested states:
+        -- * `rw`/`rewrite`: each rewrite rule nests its own intermediate state inside the region.
+        -- * `obtain`/`have`/`let`/`suffices`/`replace`: a `… by …`/`… := by …` discharges a goal with
+        --   a nested `by` block, whose states should stay nested inside the whole-tactic region.
+        unless stx.getKind ∈ nestedTacticKinds do
           tactics := false
   highlightSpecial trees stx tactics (lookingAt := lookingAt) fun trees tactics lookingAt => fun
     | .missing => pure () -- TODO emit unhighlighted string


### PR DESCRIPTION
This shows proof states for tactics like `obtain` that include an inner tactic script, but where the outer tactics are also useful.

Note that this will require some adaptation for HTML display in the default Verso renderer, which has little lozenge widgets for proof state toggles. When an empty set of goals ends at the same position as an enclosing non-empty set of goals, the inner one should be elided to prevent unneeded nesting of widgets.