### PR TITLE
feat: load module dynlibs/plugins in the highlight extractor

### DIFF
--- a/ExtractModule.lean
+++ b/ExtractModule.lean
@@ -27,6 +27,11 @@ OPTS may be:
   --suppress-namespaces FILE
     Suppress the showing of the whitespace-delimited list of namespaces in FILE
 
+  --load-dynlib PATH
+    Load the native shared library at PATH before elaboration, so that
+    `@[extern]` declarations (e.g. FFI-backed tactics) resolve when the
+    interpreter runs code. May be given multiple times.
+
   --not-server
     When elaborating a module, import only the public parts. This emulates the
     behavior of the command-line compiler instead of the language server.
@@ -75,9 +80,14 @@ partial def commandKind (cmd : Syntax) : SyntaxNodeKind :=
   | `(command|$_cmd1 in $cmd2) => commandKind cmd2
   | _ => cmd.getKind
 
-unsafe def go (asServer : Bool) (suppressedNamespaces : Array Name) (mod : String) (out : IO.FS.Stream) : IO UInt32 := do
+unsafe def go (asServer : Bool) (suppressedNamespaces : Array Name) (dynlibs : Array System.FilePath) (mod : String) (out : IO.FS.Stream) : IO UInt32 := do
   try
     initSearchPath (← findSysroot)
+    -- Load the module's native shared libraries (extern libs and precompiled
+    -- module plugins) so that `@[extern]` declarations resolve when the
+    -- interpreter runs code during elaboration — e.g. FFI-backed tactics.
+    for lib in dynlibs do
+      Lean.loadDynlib lib
     let modName := mod.toName
 
     let sp ← Compat.initSrcSearchPath
@@ -132,41 +142,47 @@ unsafe def go (asServer : Bool) (suppressedNamespaces : Array Name) (mod : Strin
 structure Config where
   asServer : Bool
   suppressedNamespaces : Array Name := #[]
+  dynlibs : Array System.FilePath := #[]
   mod : String
   outFile : Option String := none
 
-def Config.fromArgs (args : List String) : IO Config := go true #[] args
+def Config.fromArgs (args : List String) : IO Config := go true #[] #[] args
 where
-  go (asServer : Bool) (nss : Array Name) : List String → IO Config
+  go (asServer : Bool) (nss : Array Name) (libs : Array System.FilePath) : List String → IO Config
     | "--suppress-namespace" :: more =>
       if let ns :: more := more then
-        go asServer (nss.push ns.toName) more
+        go asServer (nss.push ns.toName) libs more
       else
         throw <| .userError "No namespace given after --suppress-namespace"
     | "--suppress-namespaces" :: more => do
       if let file :: more := more then
         let contents ← IO.FS.readFile file
         let nss' := Compat.String.splitToList contents (·.isWhitespace) |>.filter (!·.isEmpty) |>.map (·.toName)
-        go asServer (nss ++ nss') more
+        go asServer (nss ++ nss') libs more
       else
         throw <| .userError "No namespace file given after --suppress-namespaces"
+    | "--load-dynlib" :: more =>
+      if let lib :: more := more then
+        go asServer nss (libs.push ⟨lib⟩) more
+      else
+        throw <| .userError "No path given after --load-dynlib"
     | "--not-server" :: more => do
-      go false nss more
-    | [mod] => pure { asServer, suppressedNamespaces := nss, mod }
-    | [mod, outFile] => pure { asServer, suppressedNamespaces := nss, mod, outFile := some outFile }
+      go false nss libs more
+    | [mod] => pure { asServer, suppressedNamespaces := nss, dynlibs := libs, mod }
+    | [mod, outFile] => pure { asServer, suppressedNamespaces := nss, dynlibs := libs, mod, outFile := some outFile }
     | other => throw <| .userError s!"Didn't understand remaining arguments: {other}"
 
 unsafe def main (args : List String) : IO UInt32 := do
   try
-    let { asServer, suppressedNamespaces, mod, outFile } ← Config.fromArgs args
+    let { asServer, suppressedNamespaces, dynlibs, mod, outFile } ← Config.fromArgs args
     match outFile with
     | none =>
-      go asServer suppressedNamespaces mod (← IO.getStdout)
+      go asServer suppressedNamespaces dynlibs mod (← IO.getStdout)
     | some outFile =>
       if let some p := (outFile : System.FilePath).parent then
         IO.FS.createDirAll p
       IO.FS.withFile outFile .write fun h =>
-        go asServer suppressedNamespaces mod (.ofHandle h)
+        go asServer suppressedNamespaces dynlibs mod (.ofHandle h)
   catch e =>
     if args.isEmpty then
       IO.eprintln s!"No arguments provided."

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -218,12 +218,14 @@ else
         let dynlibArgs : Array String :=
           dynlibs.toList.flatMap (fun p => ["--load-dynlib", p.toString]) |>.toArray
 
-        -- Rebuild if the SubVerso executable, the module, or the set of native
-        -- libraries changes.
+        -- Rebuild if the SubVerso executable, the module, the set of native
+        -- libraries, or any of their contents change.
         addTrace (← fetchFileTrace exeFile)
         addTrace (← fetchFileTrace oleanFile)
         addTrace (← fetchFileTrace nsFile)
         addPureTrace (String.intercalate "\n" dynlibArgs.toList)
+        for lib in dynlibs do
+          addTrace (← fetchFileTrace lib)
 
         buildFileUnlessUpToDate' (text := true) hlFile <|
           proc {

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -60,6 +60,16 @@ open Lean Elab Command Term in
   else if ty == "LeanLib → IndexBuildM (Array Lake.Module)" then
     elabCommand <| ← `(def $(mkIdent `getMods) (lib : LeanLib) : IndexBuildM (Array Lake.Module) := lib.modules.fetch)
   else throwError "Didn't recognize type of lib.modules.fetch to define compatibility shim for 'getMods': {ty}"
+
+-- `ModuleSetup.plugins` is `Array Lean.Plugin` on versions that have the
+-- `Lean.Plugin` structure, and `Array System.FilePath` on those that don't.
+-- Normalize either to a plain array of paths.
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  if (← getEnv).contains `Lean.Plugin then
+    elabCommand <| ← `(def $(mkIdent `pluginPaths) (ps : Array Lean.Plugin) : Array System.FilePath := ps.map (·.path))
+  else
+    elabCommand <| ← `(def $(mkIdent `pluginPaths) (ps : Array System.FilePath) : Array System.FilePath := ps)
 end Compat
 
 def nightly? (version : String) : Option (Nat × Nat × Nat) := do
@@ -185,6 +195,11 @@ else
 
     let exeJob ← «subverso-extract-mod».fetch
     let modJob ← mod.olean.fetch
+    -- The module's interpreter dynlibs (extern libs and precompiled-module
+    -- plugins). Passing these to the extractor lets `@[extern]` declarations
+    -- resolve when it runs code during elaboration (e.g. FFI-backed tactics);
+    -- without them such calls fail with a missing-native-symbol error.
+    let setupJob ← mod.setup.fetch
     let suppNS := (← IO.getEnv "SUBVERSO_SUPPRESS_NAMESPACES").getD ""
 
     let buildDir := ws.root.buildDir
@@ -192,21 +207,29 @@ else
     let nsFile := buildDir / "highlighted" / s!"ns-{hash suppNS}"
 
     exeJob.bindM fun exeFile =>
+      setupJob.bindM fun setup =>
       modJob.mapM fun oleanFile => do
         addPureTrace suppNS
         buildFileUnlessUpToDate' (text := true) nsFile do
           IO.FS.createDirAll (buildDir / "highlighted")
           IO.FS.writeFile nsFile suppNS
 
-        -- Rebuild if either the SubVerso executable changes, or if the module changes
+        let dynlibs := setup.dynlibs ++ Compat.pluginPaths setup.plugins
+        let dynlibArgs : Array String :=
+          dynlibs.toList.flatMap (fun p => ["--load-dynlib", p.toString]) |>.toArray
+
+        -- Rebuild if the SubVerso executable, the module, or the set of native
+        -- libraries changes.
         addTrace (← fetchFileTrace exeFile)
         addTrace (← fetchFileTrace oleanFile)
         addTrace (← fetchFileTrace nsFile)
+        addPureTrace (String.intercalate "\n" dynlibArgs.toList)
 
         buildFileUnlessUpToDate' (text := true) hlFile <|
           proc {
             cmd := exeFile.toString
-            args :=  #["--suppress-namespaces", nsFile.toString, mod.name.toString, hlFile.toString]
+            args := #["--suppress-namespaces", nsFile.toString] ++ dynlibArgs ++
+              #[mod.name.toString, hlFile.toString]
             env := ← getAugmentedEnv
           }
         pure hlFile


### PR DESCRIPTION
This PR teaches `subverso-extract-mod` to load a module's native shared libraries before it re-elaborates the module, so that `@[extern]`-backed declarations which run during elaboration — for example an FFI-backed tactic that shells out to a native solver — resolve their native symbols instead of failing highlighting extraction with `could not find native implementation of external declaration ...`. The extractor gains a repeatable `--load-dynlib PATH` option and `Lean.loadDynlib`s each path before elaboration, and the `highlighted` module facet passes the module's Lake `ModuleSetup` dynlibs together with its precompiled-module plugin libraries. A small `Compat.pluginPaths` shim normalizes `ModuleSetup.plugins`, which is `Array Lean.Plugin` on versions that have the `Lean.Plugin` structure and `Array System.FilePath` on those that don't.

Motivation: rendering a live "literate" document about an FFI-backed tactic (a Verso blog post that runs `by sos`, which calls CSDP through an FFI wrapper). Without this, the extractor's interpreter has the module's `.olean`s but none of its native code, so the tactic can't run. `LEAN_PATH`/`LD_LIBRARY_PATH` are not sufficient — nothing `dlopen`s the module libraries — which mirrors what `lean --setup` already does (`setup.dynlibs.forM Lean.loadDynlib`).

Verified building on `v4.29.0-rc7` (the current `main` toolchain, where `plugins : Array Lean.Plugin`) and `v4.30.0` (where `plugins : Array System.FilePath`), and end-to-end extracting a real FFI tactic's examples on `v4.30.0`.

A few points I'd appreciate maintainer guidance on:
- Plugins are currently loaded via `Lean.loadDynlib` (which resolves their symbols) rather than routed through `importModules`'s `plugins` argument (which would also run their initializers). Symbol resolution is sufficient for the FFI case here, but the latter may be more faithful; happy to switch if preferred.
- Only the newer (`buildFileUnlessUpToDate'`) facet branch is patched; the `useOldBind` branch is left as-is, so FFI-backed highlighting requires newer Lake. I can mirror the change there if that path can produce module setup info.
- The dynlib/plugin paths are mixed into the highlighted output's trace (via `addPureTrace`) so extraction reruns when they change; let me know if you'd prefer a different tracing approach.

🤖 Prepared with Claude Code