### PR TITLE
fix: pass Lake module setup to highlighted extractor

### DIFF
--- a/ExtractModule.lean
+++ b/ExtractModule.lean
@@ -27,6 +27,9 @@ OPTS may be:
   --suppress-namespaces FILE
     Suppress the showing of the whitespace-delimited list of namespaces in FILE
 
+  --setup FILE
+    Load Lake's module setup JSON file before elaboration
+
   --not-server
     When elaborating a module, import only the public parts. This emulates the
     behavior of the command-line compiler instead of the language server.
@@ -75,7 +78,7 @@ partial def commandKind (cmd : Syntax) : SyntaxNodeKind :=
   | `(command|$_cmd1 in $cmd2) => commandKind cmd2
   | _ => cmd.getKind
 
-unsafe def go (asServer : Bool) (suppressedNamespaces : Array Name) (mod : String) (out : IO.FS.Stream) : IO UInt32 := do
+unsafe def go (asServer : Bool) (suppressedNamespaces : Array Name) (setupFile? : Option System.FilePath) (mod : String) (out : IO.FS.Stream) : IO UInt32 := do
   try
     initSearchPath (← findSysroot)
     let modName := mod.toName
@@ -94,13 +97,18 @@ unsafe def go (asServer : Bool) (suppressedNamespaces : Array Name) (mod : Strin
     let imports := headerToImports headerStx
     enableInitializersExecution
     let isModule := Compat.isModule headerStx
-    let env ← Compat.importModules imports {} (isModule := isModule) (asServer := asServer)
+    let (env, opts) ←
+      match ← Compat.importModulesWithSetup? asServer setupFile? imports isModule with
+      | some result => pure result
+      | none => do
+        let env ← Compat.importModules imports {} (isModule := isModule) (asServer := asServer)
+        pure (env, {})
     let pctx : Context := {inputCtx := ictx}
 
     let commandState : Command.State := { env, maxRecDepth := defaultMaxRecDepth, messages := msgs }
     let scopes :=
       let sc := commandState.scopes[0]!
-      {sc with opts := sc.opts.setBool `pp.tagAppFns true } :: commandState.scopes.tail!
+      {sc with opts := opts.setBool `pp.tagAppFns true } :: commandState.scopes.tail!
     let commandState := { commandState with scopes }
     let cmdPos := parserState.pos
     let cmdSt ← IO.mkRef { commandState, parserState, cmdPos }
@@ -132,41 +140,47 @@ unsafe def go (asServer : Bool) (suppressedNamespaces : Array Name) (mod : Strin
 structure Config where
   asServer : Bool
   suppressedNamespaces : Array Name := #[]
+  setupFile : Option System.FilePath := none
   mod : String
   outFile : Option String := none
 
-def Config.fromArgs (args : List String) : IO Config := go true #[] args
+def Config.fromArgs (args : List String) : IO Config := go true #[] none args
 where
-  go (asServer : Bool) (nss : Array Name) : List String → IO Config
+  go (asServer : Bool) (nss : Array Name) (setupFile : Option System.FilePath) : List String → IO Config
     | "--suppress-namespace" :: more =>
       if let ns :: more := more then
-        go asServer (nss.push ns.toName) more
+        go asServer (nss.push ns.toName) setupFile more
       else
         throw <| .userError "No namespace given after --suppress-namespace"
     | "--suppress-namespaces" :: more => do
       if let file :: more := more then
         let contents ← IO.FS.readFile file
         let nss' := Compat.String.splitToList contents (·.isWhitespace) |>.filter (!·.isEmpty) |>.map (·.toName)
-        go asServer (nss ++ nss') more
+        go asServer (nss ++ nss') setupFile more
       else
         throw <| .userError "No namespace file given after --suppress-namespaces"
+    | "--setup" :: more =>
+      if let file :: more := more then
+        go asServer nss (some file) more
+      else
+        throw <| .userError "No setup file given after --setup"
     | "--not-server" :: more => do
-      go false nss more
-    | [mod] => pure { asServer, suppressedNamespaces := nss, mod }
-    | [mod, outFile] => pure { asServer, suppressedNamespaces := nss, mod, outFile := some outFile }
+      go false nss setupFile more
+    | [mod] => pure { asServer, suppressedNamespaces := nss, setupFile, mod }
+    | [mod, outFile] => pure { asServer, suppressedNamespaces := nss, setupFile, mod, outFile := some outFile }
     | other => throw <| .userError s!"Didn't understand remaining arguments: {other}"
 
 unsafe def main (args : List String) : IO UInt32 := do
   try
-    let { asServer, suppressedNamespaces, mod, outFile } ← Config.fromArgs args
+    let { asServer, suppressedNamespaces, setupFile, mod, outFile } ← Config.fromArgs args
     match outFile with
     | none =>
-      go asServer suppressedNamespaces mod (← IO.getStdout)
+      go asServer suppressedNamespaces setupFile mod (← IO.getStdout)
     | some outFile =>
       if let some p := (outFile : System.FilePath).parent then
         IO.FS.createDirAll p
       IO.FS.withFile outFile .write fun h =>
-        go asServer suppressedNamespaces mod (.ofHandle h)
+        go asServer suppressedNamespaces setupFile mod (.ofHandle h)
   catch e =>
     if args.isEmpty then
       IO.eprintln s!"No arguments provided."

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ objects have the following keys:
    using the `FromJson Highlighted` instance from SubVerso.
    
 The `highlighted` facet for a package, library, or module builds
-highlighted sources.
+highlighted sources. When Lake provides a module setup file, the facet
+passes it to `subverso-extract-mod` so extraction sees the same imports,
+options, plugins, and dynamic libraries as Lake's own module build.
 
 ### Helper Process
 

--- a/Tests.lean
+++ b/Tests.lean
@@ -117,6 +117,38 @@ def lakeVars :=
     "LEAN_GITHASH",
     "ELAN_TOOLCHAIN", "DYLD_LIBRARY_PATH", "LD_LIBRARY_PATH"]
 
+def runLake
+    (projectDir : String) (args : Array String)
+    (overrideToolchain : Option String := none) :
+    IO Unit := do
+
+  let projectDir : System.FilePath := projectDir
+  let toolchain ←
+    match overrideToolchain with
+    | none =>
+      let toolchainfile := projectDir / "lean-toolchain"
+      if !(← toolchainfile.pathExists) then
+        throw <| .userError s!"File {toolchainfile} doesn't exist, couldn't load project"
+      pure <| Compat.String.trim (← IO.FS.readFile toolchainfile)
+    | some override => pure override
+
+  let cmd := "elan"
+  let args := #["run", "--install", toolchain, "lake"] ++ args
+  let res ← IO.Process.output {
+    cmd, args, cwd := projectDir
+    env := lakeVars.map (·, none)
+  }
+  if res.exitCode != 0 then
+    IO.eprintln <|
+      "Lake process failed." ++
+      "\nCWD: " ++ projectDir.toString ++
+      "\nCommand: " ++ cmd ++
+      "\nArgs: " ++ repr args ++
+      "\nExit code: " ++ toString res.exitCode ++
+      "\nstdout: " ++ res.stdout ++
+      "\nstderr: " ++ res.stderr
+    throw <| .userError "Lake process failed"
+
 -- Loads a module. To work well, it really should lock the toolchain file, but that's not available
 -- in all targeted versions, so it's just part of these tests. See Verso for a version to use in
 -- documents.
@@ -334,7 +366,10 @@ def prepareDemodulizedSource : IO System.FilePath := do
   if ← src.pathExists then IO.FS.removeDirAll src
   IO.FS.createDirAll src
   copyRecursively "." src
-    (fun f => !f.startsWith "." && !(f.startsWith "demo" || f.startsWith "small-tests") && f != "lake-manifest.json")
+    (fun f =>
+      !f.startsWith "." &&
+      !(f.startsWith "demo" || f.startsWith "small-tests" || f.startsWith "ffi-tests") &&
+      f != "lake-manifest.json")
   discard <| IO.Process.run {cmd := "python3", args := #["demodulize.py", src.toString]}
   pure src
 
@@ -464,10 +499,14 @@ def fullRun (demodSrc : System.FilePath) : IO UInt32 := do
     IO.eprintln "Example proof count mismatch"
     return 1
 
+  let myToolchain := Compat.String.trim (← IO.FS.readFile "lean-toolchain")
+
+  IO.println "Checking that the highlighted facet honors Lake module setup dynlibs"
+  let ffiDir ← prepareProject "ffi-tests" myToolchain demodSrc
+  runLake ffiDir.toString #["build", "Ffi:highlighted"] (overrideToolchain := some myToolchain)
 
   let oldest := ["4.0.0", "4.1.0", "4.2.0"]
   let oldest := oldest ++ oldest.map ("v" ++ ·) |>.map ("leanprover/lean4:" ++ ·)
-  let myToolchain := Compat.String.trim (← IO.FS.readFile "lean-toolchain")
   if oldest.contains (Compat.String.trim myToolchain) then
     IO.println s!"Skipping induction/cases alts tests for old Lean toolchain {Compat.String.trim myToolchain}"
   else

--- a/Tests.lean
+++ b/Tests.lean
@@ -360,10 +360,14 @@ def toolchainRelease? (toolchain : String) : Option (Nat × Nat) := do
   | major :: minor :: _ => pure (← major.toNat?, ← minor.toNat?)
   | _ => none
 
-/-- Whether this toolchain is new enough for the Lake setup-file highlighted-facet regression. -/
+/--
+Whether this toolchain can run the FFI regression for the highlighted facet's Lake setup-file path.
+Lake provides setup files earlier, but through 4.26 this fixture's own extern `#eval` cannot load its
+dynlib during module build, before SubVerso extraction runs.
+-/
 def supportsModuleSetupFixture (toolchain : String) : Bool :=
   match toolchainRelease? toolchain with
-  | some (4, minor) => minor >= 25
+  | some (4, minor) => minor >= 27
   | some (major, _) => major > 4
   | none => false
 
@@ -532,7 +536,7 @@ def fullRun (demodSrc : System.FilePath) : IO UInt32 := do
     let ffiDir ← prepareProject "ffi-tests" myToolchain demodSrc
     runLake ffiDir.toString #["build", "Ffi:highlighted"] (overrideToolchain := some myToolchain)
   else
-    IO.println s!"Skipping Lake module setup dynlib check for old Lean toolchain {myToolchain}"
+    IO.println s!"Skipping Lake module setup dynlib fixture for Lean toolchain {myToolchain}"
 
   let oldest := ["4.0.0", "4.1.0", "4.2.0"]
   let oldest := oldest ++ oldest.map ("v" ++ ·) |>.map ("leanprover/lean4:" ++ ·)

--- a/Tests.lean
+++ b/Tests.lean
@@ -344,6 +344,29 @@ Turns a toolchain string (e.g. `leanprover/lean4:v4.8.0`) into a safe single pat
 def sanitizeToolchain (toolchain : String) : String :=
   toolchain.map fun c => if c.isAlphanum || c == '.' then c else '-'
 
+/-- Extracts the leading `major.minor` release version from a Lean toolchain string. -/
+def toolchainRelease? (toolchain : String) : Option (Nat × Nat) := do
+  let version :=
+    match Compat.String.splitToList toolchain (· == ':') with
+    | [_pkg, v] => v
+    | [v] => v
+    | _ => toolchain
+  let version := if version.startsWith "v" then Compat.String.drop version 1 else version
+  let core :=
+    match Compat.String.splitToList version (· == '-') with
+    | v :: _ => v
+    | [] => version
+  match Compat.String.splitToList core (· == '.') with
+  | major :: minor :: _ => pure (← major.toNat?, ← minor.toNat?)
+  | _ => none
+
+/-- Whether this toolchain is new enough for the Lake setup-file highlighted-facet regression. -/
+def supportsModuleSetupFixture (toolchain : String) : Bool :=
+  match toolchainRelease? toolchain with
+  | some (4, minor) => minor >= 25
+  | some (major, _) => major > 4
+  | none => false
+
 /--
 Reads a project's pinned toolchain from its `lean-toolchain` file.
 -/
@@ -387,6 +410,9 @@ def prepareProject (project : System.FilePath) (toolchain : String) (demodSrc : 
   -- artifacts or a previously-generated dependency source — those are managed below / kept warm.
   copyRecursively project buildDir
     (fun f => f != ".lake" && f != "no-mod" && f != "lake-manifest.json")
+  -- The prepared copy must run under the matrix/fixed toolchain, not under a fixture's checked-in
+  -- toolchain, because Lake may inspect or rewrite this file while building the project.
+  IO.FS.writeFile (buildDir / "lean-toolchain") toolchain
   -- Refresh the path-dependency source in place, leaving any existing `no-mod/.lake` untouched.
   copyRecursively demodSrc (buildDir / "no-mod") (fun _ => true)
   pure buildDir
@@ -501,9 +527,12 @@ def fullRun (demodSrc : System.FilePath) : IO UInt32 := do
 
   let myToolchain := Compat.String.trim (← IO.FS.readFile "lean-toolchain")
 
-  IO.println "Checking that the highlighted facet honors Lake module setup dynlibs"
-  let ffiDir ← prepareProject "ffi-tests" myToolchain demodSrc
-  runLake ffiDir.toString #["build", "Ffi:highlighted"] (overrideToolchain := some myToolchain)
+  if supportsModuleSetupFixture myToolchain then
+    IO.println "Checking that the highlighted facet honors Lake module setup dynlibs"
+    let ffiDir ← prepareProject "ffi-tests" myToolchain demodSrc
+    runLake ffiDir.toString #["build", "Ffi:highlighted"] (overrideToolchain := some myToolchain)
+  else
+    IO.println s!"Skipping Lake module setup dynlib check for old Lean toolchain {myToolchain}"
 
   let oldest := ["4.0.0", "4.1.0", "4.2.0"]
   let oldest := oldest ++ oldest.map ("v" ++ ·) |>.map ("leanprover/lean4:" ++ ·)

--- a/Tests.lean
+++ b/Tests.lean
@@ -344,32 +344,17 @@ Turns a toolchain string (e.g. `leanprover/lean4:v4.8.0`) into a safe single pat
 def sanitizeToolchain (toolchain : String) : String :=
   toolchain.map fun c => if c.isAlphanum || c == '.' then c else '-'
 
-/-- Extracts the leading `major.minor` release version from a Lean toolchain string. -/
-def toolchainRelease? (toolchain : String) : Option (Nat × Nat) := do
-  let version :=
-    match Compat.String.splitToList toolchain (· == ':') with
-    | [_pkg, v] => v
-    | [v] => v
-    | _ => toolchain
-  let version := if version.startsWith "v" then Compat.String.drop version 1 else version
-  let core :=
-    match Compat.String.splitToList version (· == '-') with
-    | v :: _ => v
-    | [] => version
-  match Compat.String.splitToList core (· == '.') with
-  | major :: minor :: _ => pure (← major.toNat?, ← minor.toNat?)
-  | _ => none
-
-/--
-Whether this toolchain can run the FFI regression for the highlighted facet's Lake setup-file path.
-Lake provides setup files earlier, but through 4.26 this fixture's own extern `#eval` cannot load its
-dynlib during module build, before SubVerso extraction runs.
--/
-def supportsModuleSetupFixture (toolchain : String) : Bool :=
-  match toolchainRelease? toolchain with
-  | some (4, minor) => minor >= 27
-  | some (major, _) => major > 4
-  | none => false
+-- The fixture's `lp_ffi_answer` symbol uses package-aware module names, so probe the corresponding
+-- setup features rather than inferring them from the Lean version.
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  let env ← getEnv
+  let supports :=
+    env.contains `Lean.ModuleSetup.package? &&
+    env.contains `Lean.Environment.setModulePackage
+  elabCommand <| ← `(
+    def $(mkIdent `supportsModuleSetupFixture) : Bool := $(quote supports)
+  )
 
 /--
 Reads a project's pinned toolchain from its `lean-toolchain` file.
@@ -531,7 +516,7 @@ def fullRun (demodSrc : System.FilePath) : IO UInt32 := do
 
   let myToolchain := Compat.String.trim (← IO.FS.readFile "lean-toolchain")
 
-  if supportsModuleSetupFixture myToolchain then
+  if supportsModuleSetupFixture then
     IO.println "Checking that the highlighted facet honors Lake module setup dynlibs"
     let ffiDir ← prepareProject "ffi-tests" myToolchain demodSrc
     runLake ffiDir.toString #["build", "Ffi:highlighted"] (overrideToolchain := some myToolchain)

--- a/ffi-tests/Ffi.lean
+++ b/ffi-tests/Ffi.lean
@@ -1,0 +1,1 @@
+import Ffi.Basic

--- a/ffi-tests/Ffi/Basic.lean
+++ b/ffi-tests/Ffi/Basic.lean
@@ -1,0 +1,4 @@
+@[extern "lp_ffi_answer"]
+opaque answer : IO UInt32
+
+#eval answer

--- a/ffi-tests/ffi.c
+++ b/ffi-tests/ffi.c
@@ -1,0 +1,13 @@
+#include <lean/lean.h>
+
+#if defined(_WIN32)
+#define SUBVERSO_FFI_EXPORT __declspec(dllexport)
+#elif defined(__GNUC__) || defined(__clang__)
+#define SUBVERSO_FFI_EXPORT __attribute__((visibility("default")))
+#else
+#define SUBVERSO_FFI_EXPORT
+#endif
+
+SUBVERSO_FFI_EXPORT lean_object* lp_ffi_answer(void) {
+  return lean_io_result_mk_ok(lean_box_uint32(37));
+}

--- a/ffi-tests/lakefile.lean
+++ b/ffi-tests/lakefile.lean
@@ -1,0 +1,26 @@
+import Lake
+open Lake DSL
+open System (FilePath)
+
+require subverso from "no-mod"
+
+package «ffi» where
+  precompileModules := false
+
+target ffi.o pkg : FilePath := do
+  let srcJob ← inputFile (pkg.dir / "ffi.c") true
+  let picArgs := if System.Platform.isWindows then #[] else #["-fPIC"]
+  buildLeanO (pkg.buildDir / "native" / "ffi.o") srcJob picArgs
+
+target ffiShared pkg : Dynlib := do
+  let oJob ← fetch <| pkg.target `ffi.o
+  let libFile := pkg.sharedLibDir / nameToSharedLib "subverso_ffi_test"
+  let keepSymbolArgs :=
+    if System.Platform.isWindows then #[]
+    else if System.Platform.isOSX then #["-Wl,-u,_lp_ffi_answer"]
+    else #["-Wl,-u,lp_ffi_answer"]
+  buildLeanSharedLib "subverso_ffi_test" libFile #[oJob] #[] #[] keepSymbolArgs
+
+@[default_target]
+lean_lib Ffi where
+  dynlibs := #[`@/ffiShared]

--- a/ffi-tests/lean-toolchain
+++ b/ffi-tests/lean-toolchain
@@ -1,0 +1,1 @@
+leanprover/lean4:v4.29.0-rc2

--- a/ffi-tests/lean-toolchain
+++ b/ffi-tests/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.29.0-rc2
+leanprover/lean4:v4.32.0-rc1

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -168,8 +168,9 @@ lean_exe «subverso-helper» where
   supportInterpreter := true
 
 -- Keep the old and modern facet implementations separate: their Lake job/trace APIs differ enough
--- that factoring the full body would force more compatibility shims. Share only the small setup-file
--- argument helper above, which is the new behavior this fix needs.
+-- that factoring the full body would force more compatibility shims. The setup-file behavior is
+-- factored only at the argument level, where it does not expose old and modern Lake APIs to each
+-- other.
 meta if Compat.useOldBind then
   module_facet highlighted mod : FilePath := do
     let ws ← getWorkspace

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,18 +9,24 @@ open Lean Elab Command in
 #eval show CommandElabM Unit from do
   let env ← getEnv
   let useOldBind := mkIdent `useOldBind
-  let useSetupFile := mkIdent `useSetupFile
-  let hasBuildFileUnlessUpToDate' := env.contains `Lake.buildFileUnlessUpToDate'
-  let hasModuleSetupFile :=
-    match Lean.versionString.splitOn "." with
-    | "4" :: minor :: _ =>
-      match minor.toNat? with
-      | some n => decide (n >= 27)
-      | none => false
-    | _ => false
-  let useOld := !hasBuildFileUnlessUpToDate'
-  elabCommand <| ← `(def $useOldBind := $(quote useOld))
-  elabCommand <| ← `(def $useSetupFile := $(quote hasModuleSetupFile))
+  elabCommand <| ← `(def $useOldBind := !$(quote <| env.contains `Lake.buildFileUnlessUpToDate'))
+
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  let addSetupArg := mkIdent `addSetupArg
+  -- Feature-probe Lake's setup-file support instead of version-gating it, so older Lake keeps the
+  -- original extractor CLI while newer Lake passes the module setup file it already computes.
+  if (← getEnv).contains `Lake.Module.setupFile then
+    elabCommand <| ← `(
+      def $addSetupArg:ident (mod : Lake.Module) (args : Array String) : Lake.JobM (Array String) := do
+        Lake.addTrace (← Lake.computeTrace (Lake.TextFilePath.mk mod.setupFile))
+        pure (args ++ #["--setup", mod.setupFile.toString])
+    )
+  else
+    elabCommand <| ← `(
+      def $addSetupArg:ident (_mod : Lake.Module) (args : Array String) : Lake.JobM (Array String) :=
+        pure args
+    )
 
 open Lean Elab Command in
 #eval show CommandElabM Unit from do
@@ -161,6 +167,9 @@ lean_exe «subverso-helper» where
   root := `Helper
   supportInterpreter := true
 
+-- Keep the old and modern facet implementations separate: their Lake job/trace APIs differ enough
+-- that factoring the full body would force more compatibility shims. Share only the small setup-file
+-- argument helper above, which is the new behavior this fix needs.
 meta if Compat.useOldBind then
   module_facet highlighted mod : FilePath := do
     let ws ← getWorkspace
@@ -191,75 +200,40 @@ meta if Compat.useOldBind then
         pure (hlFile, trace)
 
 else
-  meta if Compat.useSetupFile then
-    module_facet highlighted mod : FilePath := do
-      let ws ← getWorkspace
+  module_facet highlighted mod : FilePath := do
+    let ws ← getWorkspace
 
-      let exeJob ← «subverso-extract-mod».fetch
-      let modJob ← mod.olean.fetch
-      let suppNS := (← IO.getEnv "SUBVERSO_SUPPRESS_NAMESPACES").getD ""
+    let exeJob ← «subverso-extract-mod».fetch
+    let modJob ← mod.olean.fetch
+    let suppNS := (← IO.getEnv "SUBVERSO_SUPPRESS_NAMESPACES").getD ""
 
-      let buildDir := ws.root.buildDir
-      let hlFile := mod.filePath (buildDir / "highlighted") "json"
-      let nsFile := buildDir / "highlighted" / s!"ns-{hash suppNS}"
+    let buildDir := ws.root.buildDir
+    let hlFile := mod.filePath (buildDir / "highlighted") "json"
+    let nsFile := buildDir / "highlighted" / s!"ns-{hash suppNS}"
 
-      exeJob.bindM fun exeFile =>
-        modJob.mapM fun oleanFile => do
-          addPureTrace suppNS
-          buildFileUnlessUpToDate' (text := true) nsFile do
-            IO.FS.createDirAll (buildDir / "highlighted")
-            IO.FS.writeFile nsFile suppNS
+    exeJob.bindM fun exeFile =>
+      modJob.mapM fun oleanFile => do
+        addPureTrace suppNS
+        buildFileUnlessUpToDate' (text := true) nsFile do
+          IO.FS.createDirAll (buildDir / "highlighted")
+          IO.FS.writeFile nsFile suppNS
 
-          -- Rebuild when the SubVerso executable, the module's source, or the compiled module
-          -- changes. Changes to the source code that don't change the olean must also be reflected
-          -- in semantically-highlighted source, so the Lean file is important here.
-          addTrace (← computeTrace exeFile)
-          addTrace (← computeTrace (TextFilePath.mk mod.leanFile))
-          addTrace (← computeTrace oleanFile)
-          addTrace (← computeTrace (TextFilePath.mk mod.setupFile))
-          addTrace (← computeTrace (TextFilePath.mk nsFile))
+        -- Rebuild when the SubVerso executable, the module's source, or the compiled module
+        -- changes. Changes to the source code that don't change the olean must also be reflected
+        -- in semantically-highlighted source, so the Lean file is important here.
+        addTrace (← computeTrace exeFile)
+        addTrace (← computeTrace (TextFilePath.mk mod.leanFile))
+        addTrace (← computeTrace oleanFile)
+        addTrace (← computeTrace (TextFilePath.mk nsFile))
 
-          buildFileUnlessUpToDate' (text := true) hlFile <|
-            proc {
-              cmd := exeFile.toString
-              args :=  #["--suppress-namespaces", nsFile.toString, "--setup", mod.setupFile.toString, mod.name.toString, hlFile.toString]
-              env := ← getAugmentedEnv
-            }
-          pure hlFile
-  else
-    module_facet highlighted mod : FilePath := do
-      let ws ← getWorkspace
-
-      let exeJob ← «subverso-extract-mod».fetch
-      let modJob ← mod.olean.fetch
-      let suppNS := (← IO.getEnv "SUBVERSO_SUPPRESS_NAMESPACES").getD ""
-
-      let buildDir := ws.root.buildDir
-      let hlFile := mod.filePath (buildDir / "highlighted") "json"
-      let nsFile := buildDir / "highlighted" / s!"ns-{hash suppNS}"
-
-      exeJob.bindM fun exeFile =>
-        modJob.mapM fun oleanFile => do
-          addPureTrace suppNS
-          buildFileUnlessUpToDate' (text := true) nsFile do
-            IO.FS.createDirAll (buildDir / "highlighted")
-            IO.FS.writeFile nsFile suppNS
-
-          -- Rebuild when the SubVerso executable, the module's source, or the compiled module
-          -- changes. Changes to the source code that don't change the olean must also be reflected
-          -- in semantically-highlighted source, so the Lean file is important here.
-          addTrace (← computeTrace exeFile)
-          addTrace (← computeTrace (TextFilePath.mk mod.leanFile))
-          addTrace (← computeTrace oleanFile)
-          addTrace (← computeTrace (TextFilePath.mk nsFile))
-
-          buildFileUnlessUpToDate' (text := true) hlFile <|
-            proc {
-              cmd := exeFile.toString
-              args :=  #["--suppress-namespaces", nsFile.toString, mod.name.toString, hlFile.toString]
-              env := ← getAugmentedEnv
-            }
-          pure hlFile
+        let args ← Compat.addSetupArg mod #["--suppress-namespaces", nsFile.toString]
+        buildFileUnlessUpToDate' (text := true) hlFile <|
+          proc {
+            cmd := exeFile.toString
+            args := args ++ #[mod.name.toString, hlFile.toString]
+            env := ← getAugmentedEnv
+          }
+        pure hlFile
 
 meta if Compat.useOldBind then
   module_facet examples mod : FilePath := do

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -167,10 +167,8 @@ lean_exe «subverso-helper» where
   root := `Helper
   supportInterpreter := true
 
--- Keep the old and modern facet implementations separate: their Lake job/trace APIs differ enough
--- that factoring the full body would force more compatibility shims. The setup-file behavior is
--- factored only at the argument level, where it does not expose old and modern Lake APIs to each
--- other.
+-- Lake's job-binding API changed, so the old and modern implementations remain separate. Module
+-- setup files were introduced after that change and are handled only by the modern branch.
 meta if Compat.useOldBind then
   module_facet highlighted mod : FilePath := do
     let ws ← getWorkspace

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,7 +9,18 @@ open Lean Elab Command in
 #eval show CommandElabM Unit from do
   let env ← getEnv
   let useOldBind := mkIdent `useOldBind
-  elabCommand <| ← `(def $useOldBind := !$(quote <| env.contains `Lake.buildFileUnlessUpToDate'))
+  let useSetupFile := mkIdent `useSetupFile
+  let hasBuildFileUnlessUpToDate' := env.contains `Lake.buildFileUnlessUpToDate'
+  let hasModuleSetupFile :=
+    match Lean.versionString.splitOn "." with
+    | "4" :: minor :: _ =>
+      match minor.toNat? with
+      | some n => decide (n >= 27)
+      | none => false
+    | _ => false
+  let useOld := !hasBuildFileUnlessUpToDate'
+  elabCommand <| ← `(def $useOldBind := $(quote useOld))
+  elabCommand <| ← `(def $useSetupFile := $(quote hasModuleSetupFile))
 
 open Lean Elab Command in
 #eval show CommandElabM Unit from do
@@ -180,39 +191,75 @@ meta if Compat.useOldBind then
         pure (hlFile, trace)
 
 else
-  module_facet highlighted mod : FilePath := do
-    let ws ← getWorkspace
+  meta if Compat.useSetupFile then
+    module_facet highlighted mod : FilePath := do
+      let ws ← getWorkspace
 
-    let exeJob ← «subverso-extract-mod».fetch
-    let modJob ← mod.olean.fetch
-    let suppNS := (← IO.getEnv "SUBVERSO_SUPPRESS_NAMESPACES").getD ""
+      let exeJob ← «subverso-extract-mod».fetch
+      let modJob ← mod.olean.fetch
+      let suppNS := (← IO.getEnv "SUBVERSO_SUPPRESS_NAMESPACES").getD ""
 
-    let buildDir := ws.root.buildDir
-    let hlFile := mod.filePath (buildDir / "highlighted") "json"
-    let nsFile := buildDir / "highlighted" / s!"ns-{hash suppNS}"
+      let buildDir := ws.root.buildDir
+      let hlFile := mod.filePath (buildDir / "highlighted") "json"
+      let nsFile := buildDir / "highlighted" / s!"ns-{hash suppNS}"
 
-    exeJob.bindM fun exeFile =>
-      modJob.mapM fun oleanFile => do
-        addPureTrace suppNS
-        buildFileUnlessUpToDate' (text := true) nsFile do
-          IO.FS.createDirAll (buildDir / "highlighted")
-          IO.FS.writeFile nsFile suppNS
+      exeJob.bindM fun exeFile =>
+        modJob.mapM fun oleanFile => do
+          addPureTrace suppNS
+          buildFileUnlessUpToDate' (text := true) nsFile do
+            IO.FS.createDirAll (buildDir / "highlighted")
+            IO.FS.writeFile nsFile suppNS
 
-        -- Rebuild when the SubVerso executable, the module's source, or the compiled module
-        -- changes. Changes to the source code that don't change the olean must also be reflected
-        -- in semantically-highlighted source, so the Lean file is important here.
-        addTrace (← computeTrace exeFile)
-        addTrace (← computeTrace (TextFilePath.mk mod.leanFile))
-        addTrace (← computeTrace oleanFile)
-        addTrace (← computeTrace (TextFilePath.mk nsFile))
+          -- Rebuild when the SubVerso executable, the module's source, or the compiled module
+          -- changes. Changes to the source code that don't change the olean must also be reflected
+          -- in semantically-highlighted source, so the Lean file is important here.
+          addTrace (← computeTrace exeFile)
+          addTrace (← computeTrace (TextFilePath.mk mod.leanFile))
+          addTrace (← computeTrace oleanFile)
+          addTrace (← computeTrace (TextFilePath.mk mod.setupFile))
+          addTrace (← computeTrace (TextFilePath.mk nsFile))
 
-        buildFileUnlessUpToDate' (text := true) hlFile <|
-          proc {
-            cmd := exeFile.toString
-            args :=  #["--suppress-namespaces", nsFile.toString, mod.name.toString, hlFile.toString]
-            env := ← getAugmentedEnv
-          }
-        pure hlFile
+          buildFileUnlessUpToDate' (text := true) hlFile <|
+            proc {
+              cmd := exeFile.toString
+              args :=  #["--suppress-namespaces", nsFile.toString, "--setup", mod.setupFile.toString, mod.name.toString, hlFile.toString]
+              env := ← getAugmentedEnv
+            }
+          pure hlFile
+  else
+    module_facet highlighted mod : FilePath := do
+      let ws ← getWorkspace
+
+      let exeJob ← «subverso-extract-mod».fetch
+      let modJob ← mod.olean.fetch
+      let suppNS := (← IO.getEnv "SUBVERSO_SUPPRESS_NAMESPACES").getD ""
+
+      let buildDir := ws.root.buildDir
+      let hlFile := mod.filePath (buildDir / "highlighted") "json"
+      let nsFile := buildDir / "highlighted" / s!"ns-{hash suppNS}"
+
+      exeJob.bindM fun exeFile =>
+        modJob.mapM fun oleanFile => do
+          addPureTrace suppNS
+          buildFileUnlessUpToDate' (text := true) nsFile do
+            IO.FS.createDirAll (buildDir / "highlighted")
+            IO.FS.writeFile nsFile suppNS
+
+          -- Rebuild when the SubVerso executable, the module's source, or the compiled module
+          -- changes. Changes to the source code that don't change the olean must also be reflected
+          -- in semantically-highlighted source, so the Lean file is important here.
+          addTrace (← computeTrace exeFile)
+          addTrace (← computeTrace (TextFilePath.mk mod.leanFile))
+          addTrace (← computeTrace oleanFile)
+          addTrace (← computeTrace (TextFilePath.mk nsFile))
+
+          buildFileUnlessUpToDate' (text := true) hlFile <|
+            proc {
+              cmd := exeFile.toString
+              args :=  #["--suppress-namespaces", nsFile.toString, mod.name.toString, hlFile.toString]
+              env := ← getAugmentedEnv
+            }
+          pure hlFile
 
 meta if Compat.useOldBind then
   module_facet examples mod : FilePath := do

--- a/src/SubVerso/Compat.lean
+++ b/src/SubVerso/Compat.lean
@@ -258,25 +258,25 @@ def isModule (stx : Syntax) : Bool :=
 
 set_option linter.unusedVariables false in
 open CanBeArrayOrList in
-def importModules [CanBeArrayOrList f] (imports : f Import) (opts : Options) (trustLevel : UInt32 := 0) (isModule : Bool := false) (asServer : Bool := false) (plugins : Array System.FilePath := #[]) : IO Environment :=
+def importModules [CanBeArrayOrList f] (imports : f Import) (opts : Options) (trustLevel : UInt32 := 0) (isModule : Bool := false) (asServer : Bool := false) : IO Environment :=
   %first_succeeding [
-    Lean.importModules (%first_succeeding [asArray imports, asList imports]) opts (trustLevel := trustLevel) (plugins := plugins) (loadExts := true) (level := if isModule then if asServer then .server else .exported else .private),
-    Lean.importModules (%first_succeeding [asArray imports, asList imports]) opts (trustLevel := trustLevel) (plugins := plugins) (loadExts := true),
+    Lean.importModules (%first_succeeding [asArray imports, asList imports]) opts (trustLevel := trustLevel) (loadExts := true) (level := if isModule then if asServer then .server else .exported else .private),
     Lean.importModules (%first_succeeding [asArray imports, asList imports]) opts (trustLevel := trustLevel) (loadExts := true),
     Lean.importModules (%first_succeeding [asArray imports, asList imports]) opts (trustLevel := trustLevel)
   ]
 
 open Lean Elab Command in
 #eval show CommandElabM Unit from do
-  if (← getEnv).contains `Lean.Environment.setModulePackage then
-    elabCommand <| ← `(def $(mkIdent `setModulePackage) (env : Lean.Environment) (pkg? : Option String) : Lean.Environment := env.setModulePackage pkg?)
-  else
-    elabCommand <| ← `(def $(mkIdent `setModulePackage) (env : Lean.Environment) (_pkg? : Option String) : Lean.Environment := env)
-
-open Lean Elab Command in
-#eval show CommandElabM Unit from do
   let importModulesWithSetup := mkIdent `importModulesWithSetup?
-  if (← getEnv).contains `Lean.ModuleSetup then
+  let env ← getEnv
+  -- Older Lean versions also had `ModuleSetup`, but with a different JSON schema.
+  -- Gate on the fields used by the Lake setup files that `lean --setup` consumes here.
+  if env.contains `Lean.ModuleSetup.imports? && env.contains `Lean.ModuleSetup.importArts then
+    let setModuleName ←
+      if env.contains `Lean.ModuleSetup.package? && env.contains `Lean.Environment.setModulePackage then
+        `(Lean.Environment.setModulePackage setup.package? (env.setMainModule setup.name))
+      else
+        `(env.setMainModule setup.name)
     elabCommand <| ← `(
       def $importModulesWithSetup:ident
           (asServer : Bool) (setupFile? : Option System.FilePath) (headerImports : Array Import)
@@ -291,16 +291,18 @@ open Lean Elab Command in
         let level := if isModule then if asServer then .server else .exported else .private
         let env ← Lean.importModules imports opts (trustLevel := 0) (plugins := setup.plugins)
           (loadExts := true) (level := level) (arts := setup.importArts)
-        let env := env.setMainModule setup.name
-        let env := setModulePackage env setup.package?
+        let env := $setModuleName:term
         pure <| some (env, opts)
     )
   else
     elabCommand <| ← `(
       def $importModulesWithSetup:ident
-          (_asServer : Bool) (_setupFile? : Option System.FilePath) (_headerImports : Array Import)
+          (_asServer : Bool) (setupFile? : Option System.FilePath) (_headerImports : Array Import)
           (_headerIsModule : Bool) : IO (Option (Environment × Options)) := do
-        pure none
+        match setupFile? with
+        | none => pure none
+        | some _ =>
+          throw <| IO.userError "--setup is not supported by this Lean version"
     )
 
 

--- a/src/SubVerso/Compat.lean
+++ b/src/SubVerso/Compat.lean
@@ -258,12 +258,50 @@ def isModule (stx : Syntax) : Bool :=
 
 set_option linter.unusedVariables false in
 open CanBeArrayOrList in
-def importModules [CanBeArrayOrList f] (imports : f Import) (opts : Options) (trustLevel : UInt32 := 0) (isModule : Bool := false) (asServer : Bool := false) : IO Environment :=
+def importModules [CanBeArrayOrList f] (imports : f Import) (opts : Options) (trustLevel : UInt32 := 0) (isModule : Bool := false) (asServer : Bool := false) (plugins : Array System.FilePath := #[]) : IO Environment :=
   %first_succeeding [
-    Lean.importModules (%first_succeeding [asArray imports, asList imports]) opts (trustLevel := trustLevel) (loadExts := true) (level := if isModule then if asServer then .server else .exported else .private),
+    Lean.importModules (%first_succeeding [asArray imports, asList imports]) opts (trustLevel := trustLevel) (plugins := plugins) (loadExts := true) (level := if isModule then if asServer then .server else .exported else .private),
+    Lean.importModules (%first_succeeding [asArray imports, asList imports]) opts (trustLevel := trustLevel) (plugins := plugins) (loadExts := true),
     Lean.importModules (%first_succeeding [asArray imports, asList imports]) opts (trustLevel := trustLevel) (loadExts := true),
     Lean.importModules (%first_succeeding [asArray imports, asList imports]) opts (trustLevel := trustLevel)
   ]
+
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  if (← getEnv).contains `Lean.Environment.setModulePackage then
+    elabCommand <| ← `(def $(mkIdent `setModulePackage) (env : Lean.Environment) (pkg? : Option String) : Lean.Environment := env.setModulePackage pkg?)
+  else
+    elabCommand <| ← `(def $(mkIdent `setModulePackage) (env : Lean.Environment) (_pkg? : Option String) : Lean.Environment := env)
+
+open Lean Elab Command in
+#eval show CommandElabM Unit from do
+  let importModulesWithSetup := mkIdent `importModulesWithSetup?
+  if (← getEnv).contains `Lean.ModuleSetup then
+    elabCommand <| ← `(
+      def $importModulesWithSetup:ident
+          (asServer : Bool) (setupFile? : Option System.FilePath) (headerImports : Array Import)
+          (headerIsModule : Bool) : IO (Option (Environment × Options)) := do
+        let some setupFile := setupFile?
+          | pure none
+        let setup ← Lean.ModuleSetup.load setupFile
+        setup.dynlibs.forM Lean.loadDynlib
+        let opts := setup.options.toOptions
+        let imports := setup.imports?.getD headerImports
+        let isModule := setup.isModule || headerIsModule
+        let level := if isModule then if asServer then .server else .exported else .private
+        let env ← Lean.importModules imports opts (trustLevel := 0) (plugins := setup.plugins)
+          (loadExts := true) (level := level) (arts := setup.importArts)
+        let env := env.setMainModule setup.name
+        let env := setModulePackage env setup.package?
+        pure <| some (env, opts)
+    )
+  else
+    elabCommand <| ← `(
+      def $importModulesWithSetup:ident
+          (_asServer : Bool) (_setupFile? : Option System.FilePath) (_headerImports : Array Import)
+          (_headerIsModule : Bool) : IO (Option (Environment × Options)) := do
+        pure none
+    )
 
 
 def mkRefIdentFVar [Monad m] [MonadEnv m] (id : FVarId) : m Lean.Lsp.RefIdent := do

--- a/src/SubVerso/Compat.lean
+++ b/src/SubVerso/Compat.lean
@@ -279,13 +279,15 @@ open Lean Elab Command in
         `(env.setMainModule setup.name)
     elabCommand <| ← `(
       def $importModulesWithSetup:ident
-          (asServer : Bool) (setupFile? : Option System.FilePath) (headerImports : Array Import)
+          {f : Type → Type} [CanBeArrayOrList f]
+          (asServer : Bool) (setupFile? : Option System.FilePath) (headerImports : f Import)
           (headerIsModule : Bool) : IO (Option (Environment × Options)) := do
         let some setupFile := setupFile?
           | pure none
         let setup ← Lean.ModuleSetup.load setupFile
         setup.dynlibs.forM Lean.loadDynlib
         let opts := setup.options.toOptions
+        let headerImports := CanBeArrayOrList.asArray headerImports
         let imports := setup.imports?.getD headerImports
         let isModule := setup.isModule || headerIsModule
         let level := if isModule then if asServer then .server else .exported else .private
@@ -297,7 +299,8 @@ open Lean Elab Command in
   else
     elabCommand <| ← `(
       def $importModulesWithSetup:ident
-          (_asServer : Bool) (setupFile? : Option System.FilePath) (_headerImports : Array Import)
+          {f : Type → Type} [CanBeArrayOrList f]
+          (_asServer : Bool) (setupFile? : Option System.FilePath) (_headerImports : f Import)
           (_headerIsModule : Bool) : IO (Option (Environment × Options)) := do
         match setupFile? with
         | none => pure none


### PR DESCRIPTION
Fix highlighted source extraction for modules whose Lake build context includes setup data, such as dynamic libraries.

The highlighted module facet now passes Lake's module setup file to `subverso-extract-mod` when Lake exposes one. The extractor loads that setup before elaboration, so extraction sees the same imports, options, plugins, import artifacts, dynamic libraries, and package metadata as the module build. Older Lake versions continue using the existing extractor arguments.

This adds an FFI regression fixture that builds a dynamic library and checks `Ffi:highlighted`. The fixture runs on Lean 4.27 and newer; setup files exist in some earlier module-system releases, but this fixture's extern `#eval` fails during the module build before SubVerso extraction runs there.

Related: #221 , thanks to @kim-em for submitting the report and a preliminary fix.
