### PR TITLE
chore: pin macOS CI spot checks to Intel runners

### DIFF
--- a/.github/workflows/ci-pre-module.yml
+++ b/.github/workflows/ci-pre-module.yml
@@ -52,26 +52,28 @@ jobs:
             installer: |
               curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
         # Mac runners are rare and expensive, so spot-check that the
-        # subprocess support seems OK but be less thorough
+        # subprocess support seems OK but be less thorough. Pin the macOS
+        # runner instead of using macos-latest: the current latest image is
+        # macOS 26 arm64, where older Lean-built binaries abort in dyld.
         include:
           - toolchain: "4.24.0"
             platform:
-              os: macos-latest
+              os: macos-15-intel
               installer: |
                 curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
           - toolchain: "4.9.1"
             platform:
-              os: macos-latest
+              os: macos-15-intel
               installer: |
                 curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
           - toolchain: "4.8.0"
             platform:
-              os: macos-latest
+              os: macos-15-intel
               installer: |
                 brew install elan-init
           - toolchain: "4.3.0"
             platform:
-              os: macos-latest
+              os: macos-15-intel
               installer: |
                 brew install elan-init
     name: Build and test without modules (${{ matrix.platform.os }}, ${{ matrix.platform.installer}}, ${{ matrix.toolchain}})
@@ -105,11 +107,13 @@ jobs:
             installer: |
               curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
         # Mac runners are rare and expensive, so spot-check that the
-        # subprocess support seems OK but be less thorough
+        # subprocess support seems OK but be less thorough. Pin the macOS
+        # runner instead of using macos-latest: the current latest image is
+        # macOS 26 arm64, where older Lean-built binaries abort in dyld.
         include:
           - toolchain: "4.27.0-rc1"
             platform:
-              os: macos-latest
+              os: macos-15-intel
               installer: |
                 curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y --default-toolchain none
 

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -96,7 +96,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: .lake
-          key: ${{ runner.os }}-${{ hashFiles('lakefile.lean') }}-${{ hashFiles('lean-toolchain') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lakefile.lean') }}-${{ hashFiles('lean-toolchain') }}
 
       - name: Build the project
         run: |

--- a/.github/workflows/run-prebuild.yml
+++ b/.github/workflows/run-prebuild.yml
@@ -11,27 +11,51 @@ on:
 
 jobs:
   prebuild:
-    name: Prebuild ${{ matrix.tag }}
-    runs-on: nscloud-ubuntu-22.04-amd64-8x16
+    name: Prebuild ${{ matrix.tag }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         # Keep these (project, toolchain, dir) triples in sync with `run-ci.yml`'s restore steps and
         # with `fixedTargets` in `Tests.lean`. `dir` is `sanitizeToolchain(toolchain)/project`.
         include:
-          - tag: demo-toml-v4.8.0
+          - os: nscloud-ubuntu-22.04-amd64-8x16
+            tag: demo-toml-v4.8.0
             project: demo-toml
             toolchain: "leanprover/lean4:v4.8.0"
             dir: .builds/leanprover-lean4-v4.8.0/demo-toml
-          - tag: demo-v4.3.0
+          - os: nscloud-ubuntu-22.04-amd64-8x16
+            tag: demo-v4.3.0
             project: demo
             toolchain: "leanprover/lean4:v4.3.0"
             dir: .builds/leanprover-lean4-v4.3.0/demo
-          - tag: demo-v4.8.0
+          - os: nscloud-ubuntu-22.04-amd64-8x16
+            tag: demo-v4.8.0
             project: demo
             toolchain: "leanprover/lean4:v4.8.0"
             dir: .builds/leanprover-lean4-v4.8.0/demo
-          - tag: demo-4.10.0
+          - os: nscloud-ubuntu-22.04-amd64-8x16
+            tag: demo-4.10.0
+            project: demo
+            toolchain: "leanprover/lean4:4.10.0"
+            dir: .builds/leanprover-lean4-4.10.0/demo
+          - os: macos-15-intel
+            tag: demo-toml-v4.8.0
+            project: demo-toml
+            toolchain: "leanprover/lean4:v4.8.0"
+            dir: .builds/leanprover-lean4-v4.8.0/demo-toml
+          - os: macos-15-intel
+            tag: demo-v4.3.0
+            project: demo
+            toolchain: "leanprover/lean4:v4.3.0"
+            dir: .builds/leanprover-lean4-v4.3.0/demo
+          - os: macos-15-intel
+            tag: demo-v4.8.0
+            project: demo
+            toolchain: "leanprover/lean4:v4.8.0"
+            dir: .builds/leanprover-lean4-v4.8.0/demo
+          - os: macos-15-intel
+            tag: demo-4.10.0
             project: demo
             toolchain: "leanprover/lean4:4.10.0"
             dir: .builds/leanprover-lean4-4.10.0/demo


### PR DESCRIPTION
GitHub's `macos-latest` label currently resolves to a macOS 26 arm64 runner. Older Lean toolchains can build test binaries there that abort in dyld, which breaks the macOS spot checks.

This pins those spot checks to `macos-15-intel`, includes `runner.arch` in the job-local `.lake` restore cache key, and warms the fixed demo caches on `macos-15-intel` so the macOS checks restore Intel artifacts instead of rebuilding the same demo projects cold.