### PR TITLE
fix: skip comments when extracting terms

### DIFF
--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -2,6 +2,7 @@
 import SubVerso.Examples
 import SubVerso.Highlighting.Highlighted
 import SubVerso.Highlighting.Anchors
+import SubVerso.Highlighting.String
 
 /-! These are SubVerso tests that don't involve a subprocess, to make development easier. -/
 
@@ -1075,5 +1076,45 @@ open Lean Elab Command in
 #assertKindRich "theorem t : True := by\n  have h : True := trivial\n  exact h" ":=" "delim"
 
 end TokenKinds
+
+section TermMatching
+
+/--
+`#evalMatchingExpr inp term exp` highlights `inp`, looks up `term` with `matchingExpr?`, and checks
+that the matched code renders as `exp`.
+-/
+elab "#evalMatchingExpr" inp:str term:str exp:str : command => do
+  let hl ← highlightWithPrefixedMessages inp.getString
+  let some found := hl.matchingExpr? term.getString
+    | throwErrorAt term m!"No match for {String.quote term.getString} in\n{inp.getString}"
+  if found.asString != exp.getString then
+    throwError m!"Mismatched match\n---Found:---\n{found.asString}\n\n---Expected:---\n{exp.getString}"
+
+/--
+`#evalNoMatchingExpr inp term` highlights `inp` and checks that `matchingExpr?` finds no match for
+`term`.
+-/
+elab "#evalNoMatchingExpr" inp:str term:str : command => do
+  let hl ← highlightWithPrefixedMessages inp.getString
+  if let some found := hl.matchingExpr? term.getString then
+    throwErrorAt term m!"Expected no match for {String.quote term.getString}, got\n{found.asString}"
+
+-- A term is matched across the comments that separate its tokens, and the match renders with
+-- whitespace from the search string rather than the comment.
+#evalMatchingExpr
+  "def f (b : Bool) : Option Nat :=\n  if b then\n    some 0\n  else -- nothing to report\n    none"
+  "else none" "else none"
+
+#evalMatchingExpr
+  "def f (b : Bool) : Option Nat :=\n  if b then some 0 else /- nothing to report -/ none"
+  "else none" "else none"
+
+-- Matching starts at the token after a leading comment.
+#evalMatchingExpr "-- a leading comment\ndef x := 1 + 2" "1 + 2" "1 + 2"
+
+-- Comment content is not itself matchable as a term.
+#evalNoMatchingExpr "def x := 1 -- plus 2\n" "plus 2"
+
+end TermMatching
 
 def main : IO Unit := pure ()

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -1079,6 +1079,11 @@ end TokenKinds
 
 section TermMatching
 
+-- `dropPrefix?` compares the characters of the prefix, not just its length
+#evalString "true\n" (("hello world".dropPrefix? "hello ").map (·.toString) == some "world")
+#evalString "true\n" ("hello world".dropPrefix? "hallo ").isNone
+#evalString "true\n" ("hi".dropPrefix? "hello ").isNone
+
 /--
 `#evalMatchingExpr inp term exp` highlights `inp`, looks up `term` with `matchingExpr?`, and checks
 that the matched code renders as `exp`.

--- a/src/SubVerso/Compat.lean
+++ b/src/SubVerso/Compat.lean
@@ -90,7 +90,7 @@ open Lean Elab Command
         where
           loop p1 p2 :=
             if p2 < p.stopPos then
-              if p1 < s.stopPos then
+              if p1 < s.stopPos && s.str.get p1 == p.str.get p2 then
                 loop (s.str.next p1) (p.str.next p2)
               else none
             else pure {s with startPos := p1}

--- a/src/SubVerso/Highlighting/Highlighted.lean
+++ b/src/SubVerso/Highlighting/Highlighted.lean
@@ -187,6 +187,13 @@ instance : Quote Token where
       mkCApp ``Token.mk #[quote kind, quote content]
 
 /--
+Whether the token kind is part of a comment.
+-/
+def Token.Kind.isComment : Token.Kind → Bool
+  | .lineComment | .blockComment | .commentDelim => true
+  | _ => false
+
+/--
 The canonical CSS class for a token kind.
 -/
 def Token.Kind.cssClass : Token.Kind → String

--- a/src/SubVerso/Highlighting/String.lean
+++ b/src/SubVerso/Highlighting/String.lean
@@ -46,6 +46,16 @@ partial def firstToken (hl : Highlighted) : Option (Highlighted × Highlighted) 
   | .token .. => pure (hl, .empty)
 
 /--
+Splits highlighted code into its first token that's part of a term followed by the rest of the code,
+passing over comments. If the code contains no such token, `none` is returned.
+-/
+partial def firstCodeToken (hl : Highlighted) : Option (Highlighted × Highlighted) := do
+  let (first, rest) ← firstToken hl
+  if let .token ⟨k, _⟩ := first then
+    if k.isComment then return ← firstCodeToken rest
+  return (first, rest)
+
+/--
 Returns the prefix of `hl` that matches the string `term`. The returned code has whitespace from
 `term`.
 -/
@@ -58,7 +68,7 @@ def matchingExprPrefix? (hl : Highlighted) (term : String) : Option Highlighted 
     let ws := Compat.String.takeWhile term (·.isWhitespace)
     out := out ++ .text ws
     term := Compat.String.trimLeft term
-    let (first, rest) ← firstToken hl
+    let (first, rest) ← firstCodeToken hl
     hl := rest
     let firstStr := first.toString
     let term' ← term.dropPrefix? firstStr
@@ -73,7 +83,7 @@ whitespace from `term`.
 def matchingExpr? (hl : Highlighted) (term : String) : Option Highlighted := do
   let mut hl := hl
   repeat
-    let (first, rest) ← firstToken hl
+    let (first, rest) ← firstCodeToken hl
     hl := rest
     if let some out := matchingExprPrefix? (first ++ rest) term then
       return out


### PR DESCRIPTION
Fixes a regression that was introduced when comments got their own nodes. Instead of skipping them (as is done for whitespace), they were used directly.

Also fixes a bug in the `dropPrefix?` shim that caused it to fail to compare the actual characters in the prefix, breaking the new tests.