### PR TITLE
chore: disable precompileModules for now

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -115,11 +115,11 @@ open Lean Elab Command in
 -- Old Lean doesn't have `leanOptions` field
 meta if leanOptionsExists then
   package «subverso» where
-    precompileModules := supportsPrecompile Lean.versionString
+    precompileModules := false -- supportsPrecompile Lean.versionString
     leanOptions := if supportsModuleSystem then #[⟨`experimental.module, true⟩] else #[]
 else
   package «subverso» where
-    precompileModules := supportsPrecompile Lean.versionString
+    precompileModules := false -- supportsPrecompile Lean.versionString
 
 lean_lib SubVerso where
   srcDir := "src"


### PR DESCRIPTION
This PR flips the `precompileModules` flag set in #225 to OFF again, while keeping the other changes that make the ON setting work.

This is to unblock an RC release without worrying about benchmarks for now (see verso#941). Sorry about the churn.