### PR TITLE
feat: support code actions in subverso-extract-mod

### DIFF
--- a/ExtractModule.lean
+++ b/ExtractModule.lean
@@ -6,6 +6,7 @@ Author: David Thrane Christiansen
 import SubVerso.Compat
 import SubVerso.Examples.Env
 import SubVerso.Module
+import SubVerso.Module.CodeActions
 
 open Lean Elab Frontend
 open Lean.Elab.Command hiding Context
@@ -45,6 +46,30 @@ fields:
  * \"code\": the JSON serialization of SubVerso's highlighted code datatype. The
    specifics of this representation are an implementation detail, and it should
    be deserialized using the same version of SubVerso.
+
+The top-level JSON object has a \"codeActions\" field that contains an array
+of the code actions offered in the module. Each code action is represented as
+a JSON object with the following fields:
+
+ * \"range\": the start and end source positions of the command at which the
+   action is offered, in the same format as a command's \"range\".
+
+ * \"utf8Range\": the same region as \"range\", as byte offsets into the UTF-8
+   encoding of the source.
+
+ * \"title\": the description of the action, as shown in an editor's code
+   action menu.
+
+ * \"kind\": the LSP code action kind (such as \"quickfix\"), or null if the
+   action does not declare one.
+
+ * \"isPreferred\": whether the action is marked as the preferred one at its
+   position.
+
+ * \"edits\": the text replacements performed by the action, as an array of
+   objects with \"range\", \"utf8Range\", and \"newText\" fields. Edit ranges
+   are absolute document positions and may lie outside the command at which
+   the action is offered.
 "
 
 /--
@@ -121,7 +146,14 @@ unsafe def go (asServer : Bool) (suppressedNamespaces : Array Name) (mod : Strin
       code := hl
     }
 
-    out.putStrLn (toString (Module.mk items).toJson)
+    let codeActions ←
+      try
+        extractCodeActions fm fname.toString modName (← cmdSt.get).commandState res.items
+      catch e =>
+        IO.eprintln s!"Couldn't extract code actions: {toString e}"
+        pure #[]
+
+    out.putStrLn (toString (Module.mk items codeActions).toJson)
 
     return (0 : UInt32)
 

--- a/Tests.lean
+++ b/Tests.lean
@@ -121,10 +121,10 @@ def lakeVars :=
 -- in all targeted versions, so it's just part of these tests. See Verso for a version to use in
 -- documents.
 open System in
-def loadModuleContent
+def loadModule
     (projectDir : String) (mod : String)
     (overrideToolchain : Option String := none) :
-    IO (Array ModuleItem) := do
+    IO Module.Module := do
 
   let projectDir : FilePath := projectDir
 
@@ -164,7 +164,7 @@ def loadModuleContent
   | .error err =>
     throw <| IO.userError s!"Couldn't parse JSON from output file: {err}\nIn:\n{json}"
   | .ok m =>
-    pure m.items
+    pure m
 
 
 where
@@ -185,6 +185,11 @@ where
       decorateOut "stdout" res.stdout ++
       decorateOut "stderr" res.stderr
 
+def loadModuleContent
+    (projectDir : String) (mod : String)
+    (overrideToolchain : Option String := none) :
+    IO (Array ModuleItem) := do
+  return (← loadModule projectDir mod overrideToolchain).items
 
 def desiredAnchors : List (String × String) := [
   ("cons", "  | cons : Nat → NatList → NatList\n"),
@@ -364,10 +369,14 @@ def loadExamplesIn (project : System.FilePath) (toolchain : String) (demodSrc : 
   loadExamples dir (overrideToolchain := some toolchain)
 
 /-- Loads a module from `project`, building it under `toolchain` in its per-toolchain build dir. -/
+def loadModuleIn (project : System.FilePath) (mod : String) (toolchain : String)
+    (demodSrc : System.FilePath) : IO Module.Module := do
+  let dir ← prepareProject project toolchain demodSrc
+  loadModule dir.toString mod (overrideToolchain := some toolchain)
+
 def loadModuleContentIn (project : System.FilePath) (mod : String) (toolchain : String)
     (demodSrc : System.FilePath) : IO (Array ModuleItem) := do
-  let dir ← prepareProject project toolchain demodSrc
-  loadModuleContent dir.toString mod (overrideToolchain := some toolchain)
+  return (← loadModuleIn project mod toolchain demodSrc).items
 
 /--
 The fixed (Lean-version-independent) demo builds. These don't depend on the toolchain under test, so
@@ -498,6 +507,27 @@ def fullRun (demodSrc : System.FilePath) : IO UInt32 := do
           IO.eprintln s!"{errors} errors encountered looking at proof states for induction/cases alts"
           return 1
     IO.println "Proof states for induction/cases alts OK"
+
+  -- The command code action infrastructure, core "Try this" suggestions, and #guard_msgs are all
+  -- present in the Lean core library from 4.7.0 onward.
+  let preCodeActions := ["4.0.0", "4.1.0", "4.2.0", "4.3.0", "4.4.0", "4.5.0", "4.6.0"]
+  let preCodeActions := preCodeActions ++ preCodeActions.map ("v" ++ ·) |>.map ("leanprover/lean4:" ++ ·)
+  if preCodeActions.contains myToolchain then
+    IO.println s!"Skipping code action tests for old Lean toolchain {myToolchain}"
+  else
+    IO.println s!"Checking code action extraction using Lean toolchain {myToolchain}"
+    let mod ← loadModuleIn "small-tests" "Small.CodeActions" myToolchain demodSrc
+    let titles := mod.codeActions.map (·.title)
+    let some guardMsgsAction := mod.codeActions.find? (·.title.startsWith "Update #guard_msgs")
+      | IO.eprintln s!"No code action to update #guard_msgs found in {repr titles}"
+        return 1
+    if guardMsgsAction.edits.isEmpty then
+      IO.eprintln "The #guard_msgs update action has no edits"
+      return 1
+    unless mod.codeActions.any (·.title.startsWith "Try this") do
+      IO.eprintln s!"No \"Try this\" code action found in {repr titles}"
+      return 1
+    IO.println "Code actions OK"
 
   pure 0
 

--- a/small-tests/Small/CodeActions.lean
+++ b/small-tests/Small/CodeActions.lean
@@ -1,0 +1,9 @@
+-- This module deliberately contains errors, so it's not imported from Small. It exists to test the
+-- extraction of code actions: the failing #guard_msgs offers its update action, and simp? offers a
+-- "Try this" suggestion.
+
+/-- info: wrong -/
+#guard_msgs in
+#eval 1 + 1
+
+example : 1 + 1 = 2 := by simp?

--- a/src/SubVerso.lean
+++ b/src/SubVerso.lean
@@ -9,4 +9,5 @@ public import SubVerso.Examples
 public import SubVerso.Helper
 public import SubVerso.Highlighting
 public import SubVerso.Module
+public import SubVerso.Module.CodeActions
 public import SubVerso.Signature

--- a/src/SubVerso/Compat.lean
+++ b/src/SubVerso/Compat.lean
@@ -17,6 +17,7 @@ import Lean.Elab.Import
 import Lean.Elab.DeclarationRange
 import Lean.Elab.Command
 import Lean.Widget.InteractiveDiagnostic
+public import Lean.Server.CodeActions
 
 -- nomodule skip
 import Std.Data.HashMap
@@ -42,6 +43,14 @@ open Lean Elab Command
 #eval show CommandElabM Unit from do
   if !(← getEnv).contains `Lean.MessageLog.toArray then
     let cmd ← `(def $(mkIdent `Lean.MessageLog.toArray) (msgs : Lean.MessageLog) : Array Lean.Message := msgs.toList.toArray)
+    elabCommand cmd
+
+#eval show CommandElabM Unit from do
+  if !(← getEnv).contains `Lean.Server.RequestM.runInIO then
+    let cmd ←
+      `(def $(mkIdent `Lean.Server.RequestM.runInIO) {α : Type}
+          (x : Lean.Server.RequestM α) (ctx : Lean.Server.RequestContext) : IO α :=
+        ReaderT.run x ctx |>.toIO fun e => IO.userError e.message)
     elabCommand cmd
 
 -- This was introduced in Lean 4.3.0. Older versions need the definition.
@@ -925,6 +934,174 @@ partial def processCommands (headerSyntax : Syntax) : Frontend.FrontendM Fronten
   return { headerSyntax, items := out }
 
 end Frontend
+
+namespace CodeAction
+
+open Lean.Server
+
+set_option linter.unusedVariables false in
+/--
+Builds the metadata for a synthetic document that stands in for the module being extracted.
+-/
+def mkDocumentMeta (uri : Lsp.DocumentUri) (mod : Name) (text : FileMap) : DocumentMeta :=
+  %first_succeeding [
+    { uri, mod, version := 1, text, dependencyBuildMode := .always },
+    { uri, version := 1, text, dependencyBuildMode := .always },
+    { uri, version := 1, text }
+  ]
+
+/--
+Builds a synthetic command snapshot from the final command state, with the given command's info
+trees and messages substituted in. The parser state is positioned at the end of the command's
+trailing whitespace, so position-based snapshot selection resolves a position within the command
+to this snapshot.
+-/
+def mkSnapshot (finalState : Command.State) (item : Frontend.FrontendItem) :
+    IO Snapshots.Snapshot := do
+  let cmdState := { finalState with
+    infoState := { finalState.infoState with trees := item.info },
+    messages := item.messages }
+  let endPos : String.Pos :=
+    getTrailingTailPos? item.commandSyntax |>.getD (item.commandSyntax.getTailPos? |>.getD ⟨0⟩)
+  %first_succeeding [
+    pure { stx := item.commandSyntax, mpState := { pos := endPos }, cmdState },
+    (do
+      pure {
+        beginPos := item.commandSyntax.getPos? |>.getD ⟨0⟩,
+        stx := item.commandSyntax,
+        mpState := { pos := endPos },
+        cmdState,
+        interactiveDiags := .empty,
+        tacticCache := (← IO.mkRef {})
+      })
+  ]
+
+/--
+Builds an editable document around the given snapshots. Requests against the document consult the
+metadata, the document identity, and the command snapshots; the initial snapshot is an inert stub.
+-/
+def mkEditableDocument («meta» : DocumentMeta) (snaps : List Snapshots.Snapshot) :
+    IO FileWorker.EditableDocument :=
+  %first_succeeding [
+    (do
+      pure {
+        «meta»,
+        initSnap := %first_succeeding [
+          { diagnostics := .empty,
+            metaSnap := .finished none { diagnostics := .empty },
+            ictx := «meta».mkInputContext,
+            stx := .missing,
+            result? := none },
+          { diagnostics := .empty,
+            ictx := «meta».mkInputContext,
+            stx := .missing,
+            result? := none },
+          { diagnostics := .empty,
+            ictx := «meta».mkInputContext,
+            stx := .missing,
+            result? := none,
+            cancelTk? := none }
+        ],
+        cmdSnaps := .ofList snaps,
+        diagnosticsRef := (← IO.mkRef #[]),
+        reporter := .pure ()
+      }),
+    (do
+      pure {
+        «meta»,
+        cmdSnaps := .ofList snaps,
+        cancelTk := (← Lean.Server.FileWorker.CancelToken.new)
+      })
+  ]
+
+/--
+Builds a request context around the given document, suitable for invoking code action providers
+directly. Requests to the client are answered with a failure.
+-/
+def mkRequestContext (doc : FileWorker.EditableDocument) : IO RequestContext :=
+  %first_succeeding [
+    (do
+      pure {
+        rpcSessions := {},
+        doc,
+        hLog := (← IO.getStderr),
+        initParams := { capabilities := {} },
+        cancelTk := (← RequestCancellationToken.new),
+        serverRequestEmitter := fun _ _ =>
+          pure (.pure (.failure .internalError "server requests are unavailable"))
+      }),
+    (do
+      pure {
+        rpcSessions := {},
+        srcSearchPathTask := .pure {},
+        doc,
+        hLog := (← IO.getStderr),
+        initParams := { capabilities := {} },
+        cancelTk := (← RequestCancellationToken.new)
+      }),
+    (do
+      pure {
+        rpcSessions := {},
+        srcSearchPath := {},
+        doc,
+        hLog := (← IO.getStderr),
+        initParams := { capabilities := {} }
+      }),
+    (do
+      pure {
+        rpcSessions := {},
+        srcSearchPath := {},
+        doc,
+        hLog := (← IO.getStderr),
+        hOut := (← IO.getStderr),
+        initParams := { capabilities := {} }
+      })
+  ]
+
+private def forceTask (t : RequestTask α) : RequestM α := do
+  match %first_succeeding [ServerTask.get t, Task.get t] with
+  | .ok v => pure v
+  | .error e => throw e
+
+/--
+Computes the code actions offered at the given range, dispatching every code action provider known
+to the language server. The resulting actions carry resolution data rather than computed edits;
+`resolveCodeAction` computes an action's edit.
+-/
+def codeActionsAt (params : Lsp.CodeActionParams) : RequestM (Array Lsp.CodeAction) := do
+  forceTask (← Lean.Server.handleCodeAction params)
+
+/--
+Resolves a code action returned by `codeActionsAt`, running its provider's lazy computation to
+produce its edit. Actions without a lazy computation are returned unchanged.
+-/
+def resolveCodeAction (action : Lsp.CodeAction) : RequestM Lsp.CodeAction := do
+  forceTask (← Lean.Server.handleCodeActionResolve action)
+
+/--
+All text edits contained in a workspace edit, from both its URI-keyed change map and its document
+change list. The extracted module is a single document, so every edit applies to it.
+-/
+def workspaceEditTextEdits (edit : Lsp.WorkspaceEdit) : Array Lsp.TextEdit := Id.run do
+  let mut out := #[]
+  let changes : List (Lsp.DocumentUri × Lsp.TextEditBatch) :=
+    %first_succeeding [
+      edit.changes?.map (·.toList) |>.getD [],
+      edit.changes.toList
+    ]
+  for (_, batch) in changes do
+    out := out ++ (show Array Lsp.TextEdit from batch)
+  let docChanges : Array Lsp.DocumentChange :=
+    %first_succeeding [
+      edit.documentChanges?.getD #[],
+      edit.documentChanges
+    ]
+  for c in docChanges do
+    if let .edit e := c then
+      out := out ++ (show Array Lsp.TextEdit from e.edits)
+  return out
+
+end CodeAction
 
 theorem Nat.lt_step {n m : Nat} : n < m → n < m.succ :=
   %first_succeeding -warning [

--- a/src/SubVerso/Module.lean
+++ b/src/SubVerso/Module.lean
@@ -63,18 +63,100 @@ instance : ToJson ModuleItem := ⟨ModuleItem.toJson⟩
 instance : FromJson ModuleItem := ⟨ModuleItem.fromJson?⟩
 
 /--
-A sequence of module items. The JSON instances for this type produce output that is much more
-compact than the underlying array.
+A single textual replacement performed by a code action. Both ranges denote the same absolute
+region of the document: `range` as line/column positions and `utf8Range` as byte offsets into the
+UTF-8 encoding of the source. The region may lie anywhere in the document, including outside the
+command where the action is offered.
+-/
+structure SuggestedEdit where
+  range : Lean.Position × Lean.Position
+  utf8Range : Nat × Nat
+  newText : String
+deriving Inhabited, Repr, BEq
+
+/--
+A code action offered somewhere in a module, with its edits fully computed. `range` and
+`utf8Range` both denote the source range of the command at which the action is offered.
+-/
+structure CodeAction where
+  range : Lean.Position × Lean.Position
+  utf8Range : Nat × Nat
+  title : String
+  kind? : Option String := none
+  isPreferred : Bool := false
+  edits : Array SuggestedEdit
+deriving Inhabited, Repr, BEq
+
+def utf8RangeToJson : Nat × Nat → Json
+  | (s, e) => Json.mkObj [("start", s), ("end", e)]
+
+def utf8RangeFromJson (json : Json) : Except String (Nat × Nat) := do
+  let s ← json.getObjValAs? Nat "start"
+  let e ← json.getObjValAs? Nat "end"
+  pure (s, e)
+
+def requiredRangeFromJson (json : Json) : Except String (Lean.Position × Lean.Position) := do
+  let some range ← rangeFromJson json
+    | throw "Expected a range, got null"
+  pure range
+
+def SuggestedEdit.toJson : SuggestedEdit → Json
+  | {range, utf8Range, newText} =>
+    Json.mkObj [
+      ("range", rangeToJson range),
+      ("utf8Range", utf8RangeToJson utf8Range),
+      ("newText", ToJson.toJson newText)
+    ]
+
+def SuggestedEdit.fromJson? (json : Json) : Except String SuggestedEdit := do
+  let range ← json.getObjVal? "range" >>= requiredRangeFromJson
+  let utf8Range ← json.getObjVal? "utf8Range" >>= utf8RangeFromJson
+  let newText ← json.getObjValAs? String "newText"
+  return {range, utf8Range, newText}
+
+instance : ToJson SuggestedEdit := ⟨SuggestedEdit.toJson⟩
+instance : FromJson SuggestedEdit := ⟨SuggestedEdit.fromJson?⟩
+
+def CodeAction.toJson : CodeAction → Json
+  | {range, utf8Range, title, kind?, isPreferred, edits} =>
+    Json.mkObj [
+      ("range", rangeToJson range),
+      ("utf8Range", utf8RangeToJson utf8Range),
+      ("title", ToJson.toJson title),
+      ("kind", kind?.map ToJson.toJson |>.getD .null),
+      ("isPreferred", ToJson.toJson isPreferred),
+      ("edits", ToJson.toJson edits)
+    ]
+
+def CodeAction.fromJson? (json : Json) : Except String CodeAction := do
+  let range ← json.getObjVal? "range" >>= requiredRangeFromJson
+  let utf8Range ← json.getObjVal? "utf8Range" >>= utf8RangeFromJson
+  let title ← json.getObjValAs? String "title"
+  let kind? ← match json.getObjVal? "kind" with
+    | .ok .null | .error _ => pure none
+    | .ok v => some <$> FromJson.fromJson? (α := String) v
+  let isPreferred := json.getObjValAs? Bool "isPreferred" |>.toOption |>.getD false
+  let edits ← json.getObjValAs? (Array SuggestedEdit) "edits"
+  return {range, utf8Range, title, kind?, isPreferred, edits}
+
+instance : ToJson CodeAction := ⟨CodeAction.toJson⟩
+instance : FromJson CodeAction := ⟨CodeAction.fromJson?⟩
+
+/--
+A sequence of module items, together with the code actions offered in the module. The JSON
+instances for this type produce output that is much more compact than the underlying array.
 -/
 structure Module where
   items : Array ModuleItem
+  codeActions : Array CodeAction := #[]
 deriving Inhabited
 
 def Module.toJson (mod : Module) : Json :=
   let (items, state) := mod.items.mapM itemJson |>.run {}
   Json.mkObj [
     ("data", state.toExport.toJson),
-    ("items", .arr items)
+    ("items", .arr items),
+    ("codeActions", ToJson.toJson mod.codeActions)
   ]
 where
   itemJson : ModuleItem → ExportM Json
@@ -93,7 +175,10 @@ def Module.fromJson? (json : Json) : Except String Module := do
   let data ← Export.fromJson? data
   let .arr items ← json.getObjVal? "items"
     | throw "Expected array for key 'items'"
-  return ⟨← items.mapM (getItem data)⟩
+  let codeActions : Array CodeAction ←
+    (json.getObjVal? "codeActions").toOption.map Lean.FromJson.fromJson? |>.getD (pure #[])
+  let items ← items.mapM (getItem data)
+  return { items, codeActions }
 where
   getItem (data : Export) (v : Json) : Except String ModuleItem := do
     let range ← v.getObjVal? "range" >>= rangeFromJson

--- a/src/SubVerso/Module/CodeActions.lean
+++ b/src/SubVerso/Module/CodeActions.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 Lean FRO LLC. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Author: David Thrane Christiansen
+-/
+module
+public import SubVerso.Compat
+public import SubVerso.Module
+
+public section
+
+open Lean Elab
+
+namespace SubVerso.Module
+
+/-- Converts an LSP text edit to a suggested edit with absolute document positions. -/
+def suggestedEditOfTextEdit (text : FileMap) (edit : Lsp.TextEdit) : SuggestedEdit :=
+  let start := text.lspPosToUtf8Pos edit.range.start
+  let stop := text.lspPosToUtf8Pos edit.range.end
+  { range := (text.toPosition start, text.toPosition stop),
+    utf8Range := (start.byteIdx, stop.byteIdx),
+    newText := edit.newText }
+
+/--
+Extracts the code actions offered in a module after it has been elaborated. Each command's info
+trees and messages are presented to the language server's code action handlers against the final
+command state, and every action's edit is computed. Each returned action is anchored at the range
+of the command where it is offered. On toolchains without code action support, the result is
+empty.
+-/
+def extractCodeActions (text : FileMap) (fileName : String) (mod : Name)
+    (finalState : Command.State)
+    (items : Array Compat.Frontend.FrontendItem) : IO (Array CodeAction) := do
+  let docMeta := Compat.CodeAction.mkDocumentMeta s!"file://{fileName}" mod text
+  let eligible := items.filter fun item =>
+    !Parser.isTerminalCommand item.commandSyntax && item.info.size == 1
+  let snaps ← eligible.mapM (Compat.CodeAction.mkSnapshot finalState)
+  let doc ← Compat.CodeAction.mkEditableDocument docMeta snaps.toList
+  let ctx ← Compat.CodeAction.mkRequestContext doc
+  let mut out := #[]
+  for item in eligible do
+    let some rawRange := item.commandSyntax.getRange?
+      | continue
+    let anchorRange := (text.toPosition rawRange.start, text.toPosition rawRange.stop)
+    let anchorUtf8 := (rawRange.start.byteIdx, rawRange.stop.byteIdx)
+    let params : Lsp.CodeActionParams := {
+      textDocument := ⟨docMeta.uri⟩,
+      range := {
+        start := text.utf8PosToLspPos rawRange.start,
+        «end» := text.utf8PosToLspPos rawRange.stop
+      }
+    }
+    let actions ←
+      try
+        Compat.CodeAction.codeActionsAt params |>.runInIO ctx
+      catch e =>
+        IO.eprintln s!"Code actions failed at {fileName}:{anchorRange.1.line}: {e}"
+        pure #[]
+    for eager in actions do
+      let action ←
+        if eager.edit?.isSome then pure eager
+        else
+          try
+            Compat.CodeAction.resolveCodeAction eager |>.runInIO ctx
+          catch e =>
+            IO.eprintln s!"Code action '{eager.title}' failed to compute its edit: {e}"
+            pure eager
+      let some edit := action.edit?
+        | continue
+      let edits := Compat.CodeAction.workspaceEditTextEdits edit |>.map (suggestedEditOfTextEdit text)
+      unless edits.isEmpty do
+        out := out.push {
+          range := anchorRange,
+          utf8Range := anchorUtf8,
+          title := action.title,
+          kind? := action.kind?,
+          isPreferred := action.isPreferred?.getD false,
+          edits
+        }
+  let mut seen : Array String := #[]
+  let mut deduped := #[]
+  for action in out do
+    let key := Json.mkObj [
+      ("title", ToJson.toJson action.title),
+      ("edits", ToJson.toJson action.edits)
+    ] |>.compress
+    unless seen.contains key do
+      seen := seen.push key
+      deduped := deduped.push action
+  return deduped


### PR DESCRIPTION
Adds support for code actions, primarily so version-crossing code rendering can be made more ergonomic with #guard_msgs.