### PR TITLE
fix: close message spans and tactic regions in nesting order

### DIFF
--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -1231,4 +1231,148 @@ open Lean Elab Command in
 
 end AsyncElab
 
+/-!
+# Messages that overlap tactic regions
+
+Messages nest around and interleave with tactic regions. The highlighter keeps the two kinds
+of region properly nested: a message that covers a whole proof contains the message regions
+logged inside it, and a message that ends partway into a tactic region leaves the region
+intact rather than cutting it off at the message boundary.
+-/
+
+section MessageTacticNesting
+
+open SubVerso.Highlighting
+
+open Lean Elab Tactic in
+/-- Runs a tactic sequence, first logging an informational note that covers all of it. -/
+elab "with_note " ts:Lean.Parser.Tactic.tacticSeq : tactic => do
+  logInfo "Noted"
+  evalTactic ts
+
+open Lean Elab Tactic in
+/-- Runs a tactic, first logging a warning that covers it. -/
+elab "flag_tac " t:tactic : tactic => do
+  logWarningAt t "Flagged"
+  evalTactic t
+
+open Lean Elab Tactic in
+/--
+Runs two tactics, first logging a warning whose range starts at the first tactic and ends
+partway into the second, producing a message region that overlaps the second tactic's region.
+-/
+elab "overlap_note " t1:tactic " overlapping " t2:tactic : tactic => do
+  let some b := t1.raw.getPos? | throwUnsupportedSyntax
+  let some c := t2.raw[0].getTailPos? | throwUnsupportedSyntax
+  logWarningAt (Syntax.node (.synthetic b c) nullKind #[]) "Partially covered"
+  evalTactic t1
+  evalTactic t2
+
+open Lean Elab Tactic in
+/--
+Runs two tactics, first logging a warning whose range starts partway into the first tactic
+and ends at the second tactic's end, producing a message region that overlaps the first
+tactic's region.
+-/
+elab "overlap_note' " t1:tactic " overlapping " t2:tactic : tactic => do
+  let some b := t1.raw[1].getPos? | throwUnsupportedSyntax
+  let some c := t2.raw.getTailPos? | throwUnsupportedSyntax
+  logWarningAt (Syntax.node (.synthetic b c) nullKind #[]) "Partially covered"
+  evalTactic t1
+  evalTactic t2
+
+/-- Whether the tree contains a span with a message of the given kind. -/
+partial def hasSpanKind (k : Highlighted.Span.Kind) : Highlighted → Bool
+  | .seq xs => xs.any (hasSpanKind k)
+  | .span infos content => infos.any (·.1 == k) || hasSpanKind k content
+  | .tactics _ _ _ content => hasSpanKind k content
+  | _ => false
+
+/-- Whether the tree contains a span of kind `outer` with a span of kind `inner` inside it. -/
+partial def hasNestedSpans (outer inner : Highlighted.Span.Kind) : Highlighted → Bool
+  | .seq xs => xs.any (hasNestedSpans outer inner)
+  | .span infos content =>
+    (infos.any (·.1 == outer) && hasSpanKind inner content) || hasNestedSpans outer inner content
+  | .tactics _ _ _ content => hasNestedSpans outer inner content
+  | _ => false
+
+/-- Whether the tree contains a proof state region. -/
+partial def hasTacticsNode : Highlighted → Bool
+  | .seq xs => xs.any hasTacticsNode
+  | .span _ content => hasTacticsNode content
+  | .tactics .. => true
+  | _ => false
+
+/-- Whether the tree contains a span of kind `k` with a proof state region inside it. -/
+partial def hasSpanWithTactics (k : Highlighted.Span.Kind) : Highlighted → Bool
+  | .seq xs => xs.any (hasSpanWithTactics k)
+  | .span infos content =>
+    (infos.any (·.1 == k) && hasTacticsNode content) || hasSpanWithTactics k content
+  | .tactics _ _ _ content => hasSpanWithTactics k content
+  | _ => false
+
+/-- The code covered by each span with a message of kind `k`, outermost first. -/
+partial def spanTexts (k : Highlighted.Span.Kind) : Highlighted → List String
+  | .seq xs => xs.toList.flatMap (spanTexts k)
+  | .span infos content =>
+    (if infos.any (·.1 == k) then [content.asString] else []) ++ spanTexts k content
+  | .tactics _ _ _ content => spanTexts k content
+  | _ => []
+
+open Lean Elab Command in
+-- A message that covers a whole proof contains the message regions logged inside it.
+#eval show CommandElabM Unit from do
+  let hl ← highlightModuleStyle <| String.intercalate "\n" [
+    "theorem nestedMessages (n : Nat) : n + 0 = n := by",
+    "  with_note",
+    "    induction n with",
+    "    | zero => flag_tac rfl",
+    "    | succ k ih => rfl",
+    ""]
+  unless hasNestedSpans .info .warning hl do
+    throwError m!"Expected a warning span nested in an info span:\n{hlStringWithMessages hl}"
+
+open Lean Elab Command in
+-- A message that ends partway into a tactic region leaves the region intact.
+#eval show CommandElabM Unit from do
+  let input := String.intercalate "\n" [
+    "theorem overlappedRegion : 1 + 1 = 2 := by",
+    "  overlap_note skip overlapping exact rfl",
+    ""]
+  let hl ← highlightModuleStyle input
+  let regions := hl.proofStates.toList.map (·.fst)
+  unless regions.any (·.startsWith "exact rfl") do
+    throwError s!"Expected an intact `exact rfl` region, got: {toString regions}"
+  unless hl.asString == input do
+    throwError s!"Expected the highlighted code to round-trip, got: {hl.asString}"
+
+open Lean Elab Command in
+-- A message that starts partway into a tactic region and ends after it keeps its tail.
+#eval show CommandElabM Unit from do
+  let input := String.intercalate "\n" [
+    "theorem overlappedRegionTail : 1 + 1 = 2 := by",
+    "  overlap_note' exact rfl overlapping skip",
+    ""]
+  let hl ← highlightModuleStyle input
+  let texts := spanTexts .warning hl
+  unless texts.any (fun s => (s.splitOn "skip").length > 1) do
+    throwError s!"Expected a warning span that reaches `skip`, got: {toString texts}"
+  unless hl.asString == input do
+    throwError s!"Expected the highlighted code to round-trip, got: {hl.asString}"
+
+open Lean Elab Command in
+-- A message whose range is exactly a tactic's region wraps that region.
+#eval show CommandElabM Unit from do
+  let input := String.intercalate "\n" [
+    "theorem sameExtent : 1 + 1 = 2 := by",
+    "  flag_tac rfl",
+    ""]
+  let hl ← highlightModuleStyle input
+  unless hasSpanWithTactics .warning hl do
+    throwError m!"Expected a warning span containing a proof state region:\n{hlStringWithMessages hl}"
+  unless hl.asString == input do
+    throwError s!"Expected the highlighted code to round-trip, got: {hl.asString}"
+
+end MessageTacticNesting
+
 def main : IO Unit := pure ()

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -1234,10 +1234,10 @@ end AsyncElab
 /-!
 # Messages that overlap tactic regions
 
-Messages nest around and interleave with tactic regions. The highlighter keeps the two kinds
-of region properly nested: a message that covers a whole proof contains the message regions
-logged inside it, and a message that ends partway into a tactic region leaves the region
-intact rather than cutting it off at the message boundary.
+Messages nest around and interleave with tactic regions. Both kinds of region close in nesting
+order: a message that covers a whole proof contains the message regions logged inside it, and a
+region that reaches its end while another is still open inside it stays open until the inner one
+closes, so it extends to the inner region's end.
 -/
 
 section MessageTacticNesting
@@ -1258,15 +1258,25 @@ elab "flag_tac " t:tactic : tactic => do
 
 open Lean Elab Tactic in
 /--
+Logs a warning that covers the source from `start` to `stop`, then runs `t1` followed by `t2`. The
+warning's range is chosen by the caller so that it partially overlaps one tactic's region.
+-/
+def overlappingWarning (start stop : Option Compat.String.Pos) (t1 t2 : TSyntax `tactic) :
+    TacticM Unit := do
+  let some start := start | throwError m!"No start position in {t1}"
+  let some stop := stop | throwError m!"No end position in {t2}"
+  logWarningAt (Syntax.node (.synthetic start stop) nullKind #[]) "Partially covered"
+  evalTactic t1
+  evalTactic t2
+
+open Lean Elab Tactic in
+/--
 Runs two tactics, first logging a warning whose range starts at the first tactic and ends
 partway into the second, producing a message region that overlaps the second tactic's region.
 -/
-elab "overlap_note " t1:tactic " overlapping " t2:tactic : tactic => do
-  let some b := t1.raw.getPos? | throwUnsupportedSyntax
-  let some c := t2.raw[0].getTailPos? | throwUnsupportedSyntax
-  logWarningAt (Syntax.node (.synthetic b c) nullKind #[]) "Partially covered"
-  evalTactic t1
-  evalTactic t2
+elab "overlap_note " t1:tactic " overlapping " t2:tactic : tactic =>
+  -- The warning ends at the head of `t2` (the `exact` of `exact rfl`), inside `t2`'s region
+  overlappingWarning t1.raw.getPos? t2.raw[0].getTailPos? t1 t2
 
 open Lean Elab Tactic in
 /--
@@ -1274,10 +1284,24 @@ Runs two tactics, first logging a warning whose range starts partway into the fi
 and ends at the second tactic's end, producing a message region that overlaps the first
 tactic's region.
 -/
-elab "overlap_note' " t1:tactic " overlapping " t2:tactic : tactic => do
-  let some b := t1.raw[1].getPos? | throwUnsupportedSyntax
-  let some c := t2.raw.getTailPos? | throwUnsupportedSyntax
-  logWarningAt (Syntax.node (.synthetic b c) nullKind #[]) "Partially covered"
+elab "overlap_note' " t1:tactic " overlapping " t2:tactic : tactic =>
+  -- The warning starts at the argument of `t1` (the `rfl` of `exact rfl`), inside `t1`'s region
+  overlappingWarning t1.raw[1].getPos? t2.raw.getTailPos? t1 t2
+
+open Lean Elab Tactic in
+/--
+Runs two tactics, first logging a warning that reaches partway into the second tactic and a note
+that starts there, so that the two message ranges overlap each other as well as the second
+tactic's region.
+-/
+elab "crossed_notes " t1:tactic " with " t2:tactic : tactic => do
+  let some start := t1.raw.getPos? | throwError m!"No start position in {t1}"
+  let some noteStart := t2.raw.getPos? | throwError m!"No start position in {t2}"
+  -- The warning ends at the head of `t2` (the `exact` of `exact rfl`), inside `t2`'s region
+  let some warnStop := t2.raw[0].getTailPos? | throwError m!"No end position in {t2}"
+  let some stop := t2.raw.getTailPos? | throwError m!"No end position in {t2}"
+  logWarningAt (Syntax.node (.synthetic start warnStop) nullKind #[]) "Warned"
+  logInfoAt (Syntax.node (.synthetic noteStart stop) nullKind #[]) "Noted"
   evalTactic t1
   evalTactic t2
 
@@ -1313,27 +1337,35 @@ partial def hasSpanWithTactics (k : Highlighted.Span.Kind) : Highlighted → Boo
 
 /-- The code covered by each span with a message of kind `k`, outermost first. -/
 partial def spanTexts (k : Highlighted.Span.Kind) : Highlighted → List String
-  | .seq xs => xs.toList.flatMap (spanTexts k)
+  | .seq xs => Compat.List.flatMap xs.toList (spanTexts k)
   | .span infos content =>
     (if infos.any (·.1 == k) then [content.asString] else []) ++ spanTexts k content
   | .tactics _ _ _ content => spanTexts k content
   | _ => []
 
 open Lean Elab Command in
+/-- Checks that `hl` reproduces `input`. -/
+def checkRoundTrip (input : String) (hl : Highlighted) : CommandElabM Unit := do
+  unless hl.asString == input do
+    throwError s!"Expected the highlighted code to round-trip, got: {hl.asString}"
+
+open Lean Elab Command in
 -- A message that covers a whole proof contains the message regions logged inside it.
 #eval show CommandElabM Unit from do
-  let hl ← highlightModuleStyle <| String.intercalate "\n" [
+  let input := String.intercalate "\n" [
     "theorem nestedMessages (n : Nat) : n + 0 = n := by",
     "  with_note",
     "    induction n with",
     "    | zero => flag_tac rfl",
     "    | succ k ih => rfl",
     ""]
+  let hl ← highlightModuleStyle input
   unless hasNestedSpans .info .warning hl do
     throwError m!"Expected a warning span nested in an info span:\n{hlStringWithMessages hl}"
+  checkRoundTrip input hl
 
 open Lean Elab Command in
--- A message that ends partway into a tactic region leaves the region intact.
+-- A message that ends partway into a tactic region stays open until the region closes.
 #eval show CommandElabM Unit from do
   let input := String.intercalate "\n" [
     "theorem overlappedRegion : 1 + 1 = 2 := by",
@@ -1341,24 +1373,26 @@ open Lean Elab Command in
     ""]
   let hl ← highlightModuleStyle input
   let regions := hl.proofStates.toList.map (·.fst)
-  unless regions.any (·.startsWith "exact rfl") do
-    throwError s!"Expected an intact `exact rfl` region, got: {toString regions}"
-  unless hl.asString == input do
-    throwError s!"Expected the highlighted code to round-trip, got: {hl.asString}"
+  unless regions.contains "exact rfl" && regions.contains "skip" do
+    throwError s!"Expected intact `skip` and `exact rfl` regions, got: {toString regions}"
+  unless spanTexts .warning hl == ["skip overlapping exact rfl"] do
+    throwError s!"Expected one warning span reaching the region's end, got: {toString (spanTexts .warning hl)}"
+  checkRoundTrip input hl
 
 open Lean Elab Command in
--- A message that starts partway into a tactic region and ends after it keeps its tail.
+-- A tactic region that reaches its end inside a message stays open until the message closes.
 #eval show CommandElabM Unit from do
   let input := String.intercalate "\n" [
     "theorem overlappedRegionTail : 1 + 1 = 2 := by",
     "  overlap_note' exact rfl overlapping skip",
     ""]
   let hl ← highlightModuleStyle input
-  let texts := spanTexts .warning hl
-  unless texts.any (fun s => (s.splitOn "skip").length > 1) do
-    throwError s!"Expected a warning span that reaches `skip`, got: {toString texts}"
-  unless hl.asString == input do
-    throwError s!"Expected the highlighted code to round-trip, got: {hl.asString}"
+  let regions := hl.proofStates.toList.map (·.fst)
+  unless regions.contains "exact rfl overlapping skip" do
+    throwError s!"Expected a region reaching the warning's end, got: {toString regions}"
+  unless spanTexts .warning hl == ["rfl overlapping skip"] do
+    throwError s!"Expected one warning span covering `rfl overlapping skip`, got: {toString (spanTexts .warning hl)}"
+  checkRoundTrip input hl
 
 open Lean Elab Command in
 -- A message whose range is exactly a tactic's region wraps that region.
@@ -1370,8 +1404,25 @@ open Lean Elab Command in
   let hl ← highlightModuleStyle input
   unless hasSpanWithTactics .warning hl do
     throwError m!"Expected a warning span containing a proof state region:\n{hlStringWithMessages hl}"
-  unless hl.asString == input do
-    throwError s!"Expected the highlighted code to round-trip, got: {hl.asString}"
+  unless spanTexts .warning hl == ["rfl"] do
+    throwError s!"Expected the warning to cover `rfl`, got: {toString (spanTexts .warning hl)}"
+  checkRoundTrip input hl
+
+open Lean Elab Command in
+-- Message ranges that overlap each other and a tactic region close in nesting order.
+#eval show CommandElabM Unit from do
+  let input := String.intercalate "\n" [
+    "theorem crossedMessages : 1 + 1 = 2 := by",
+    "  crossed_notes skip with exact rfl",
+    ""]
+  let hl ← highlightModuleStyle input
+  unless hasNestedSpans .warning .info hl do
+    throwError m!"Expected a note span nested in a warning span:\n{hlStringWithMessages hl}"
+  unless spanTexts .warning hl == ["skip with exact rfl"] do
+    throwError s!"Expected one warning span reaching the region's end, got: {toString (spanTexts .warning hl)}"
+  unless spanTexts .info hl == ["exact rfl"] do
+    throwError s!"Expected one note span covering `exact rfl`, got: {toString (spanTexts .info hl)}"
+  checkRoundTrip input hl
 
 end MessageTacticNesting
 

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -442,10 +442,6 @@ def Highlighted.fromOutput (output : List Output) : Highlighted :=
     | .tactics info startPos endPos :: more => go (.tactics info startPos.byteIdx endPos.byteIdx acc) more
   go .empty output
 
-structure OpenTactic where
-  openedAt : Compat.String.Pos
-  closesAt : Compat.String.Pos
-
 structure MessageBundle where
   messages : Array Message
   non_empty : messages.size > 0
@@ -522,12 +518,8 @@ structure HighlightState where
   /-- Messages not yet displayed -/
   messages : Array MessageBundle
   nextMessage : Option (Fin messages.size)
-  /-- Output so far -/
+  /-- Output so far. Its open `span` and `tactics` frames carry their own end positions. -/
   output : List Output
-  /-- Messages being displayed -/
-  inMessages : List MessageBundle
-  /-- A stack of currently-open tactic regions. -/
-  inTactic : List OpenTactic
   /-- Last source position added to the output -/
   lastPos? : Option Compat.String.Pos := none
   /-- Memoized results of searching for tactic info (by canonical range) -/
@@ -542,14 +534,12 @@ structure HighlightState where
   fmtTerms : Compat.HashMap Expr String := {}
 
 
-instance : Inhabited HighlightState := ⟨default, default, default, default, default, default, {}, {}, {}, {}, {}⟩
+instance : Inhabited HighlightState := ⟨default, default, default, default, {}, {}, {}, {}, {}⟩
 
 def HighlightState.empty : HighlightState where
   messages := #[]
   nextMessage := none
   output := []
-  inMessages := []
-  inTactic := []
 
 def HighlightState.resetCache (st : HighlightState) : HighlightState :=
   { st with terms := {}, ppTerms := {}, fmtTerms := {} }
@@ -563,8 +553,6 @@ def HighlightState.ofMessages [Monad m] [MonadFileMap m]
     messages := msgs
     nextMessage := if h : 0 < msgs.size then some ⟨0, h⟩ else none,
     output := [],
-    inMessages := [],
-    inTactic := []
     lastPos? := startPos?
   }
 where
@@ -589,10 +577,8 @@ private def modify? (f : α → Option α) : (xs : List α) → Option (List α)
 def HighlightState.openTactic (st : HighlightState) (info : Array (Highlighted.Goal Highlighted)) (startPos endPos : Compat.String.Pos) (_pos : Position) : HighlightState :=
   if let some out' := modify? update? st.output then
     {st with output := out'}
-  else { st with
-    output := .tactics info startPos endPos :: st.output,
-    inTactic := ⟨startPos, endPos⟩ :: st.inTactic
-  }
+  else
+    { st with output := .tactics info startPos endPos :: st.output }
 where
   update?
     | .tactics info' startPos' endPos' =>
@@ -623,9 +609,6 @@ def advanceMessages : HighlightM Unit := do
 
 def needsOpening (pos : Lean.Position) (message : MessageBundle) : Bool :=
   message.pos.notAfter pos
-
-def needsClosing (pos : Lean.Position) (message : MessageBundle) : Bool :=
-  message.endPos.map (·.notAfter pos) |>.getD true
 
 private def leanPosToUtf8Pos (text : FileMap) : Position → Compat.String.Pos :=
   text.lspPosToUtf8Pos ∘ text.leanPosToLspPos
@@ -897,38 +880,31 @@ partial def openUntil (pos : Lean.Position) : HighlightM Unit := do
           pure ⟨kind, str⟩
 
       modify fun st =>
-    {st with
-        output := Output.openSpan st.output txt (leanPosToUtf8Pos text msg.pos) (msg.endPos.map (leanPosToUtf8Pos text))
-        inMessages := msg :: st.inMessages
-      }
+        {st with
+          output := Output.openSpan st.output txt (leanPosToUtf8Pos text msg.pos) (msg.endPos.map (leanPosToUtf8Pos text))
+        }
       openUntil pos
 
+/--
+Closes the message spans and tactic regions that end at or before `pos`.
+
+`Output.closeSpan` always closes the innermost open frame, so frames close in nesting order:
+a region that has reached its end position while another region is still open inside it
+stays open until the inner one closes, which keeps overlapping regions properly nested. A
+message span with no end position closes as soon as it is the innermost open frame.
+-/
 partial def closeUntil (pos : Compat.String.Pos) : HighlightM Unit := do
-  let text ← getFileMap
   let more ← modifyGet fun st =>
-    match st.inMessages, st.inTactic with
-    | [], [] => (false, st)
-    | [], t :: ts =>
-      if t.closesAt ≤ pos then
-        (true, {st with output := Output.closeSpan st.output, inTactic := ts})
+    match st.output.find? (fun | .span .. | .tactics .. => true | _ => false) with
+    | some (.span _ _ endPos) =>
+      if endPos.map (fun e => (e ≤ pos : Bool)) |>.getD true then
+        (true, {st with output := Output.closeSpan st.output})
       else (false, st)
-    | m :: ms, [] =>
-      if needsClosing (text.toPosition pos) m then
-        (true, {st with output := Output.closeSpan st.output, inMessages := ms})
+    | some (.tactics _ _ endPos) =>
+      if endPos ≤ pos then
+        (true, {st with output := Output.closeSpan st.output})
       else (false, st)
-    | m :: ms, t :: ts =>
-      if let some e := m.endPos then
-        if text.toPosition t.closesAt |>.notAfter e then
-          -- Close the tactics first, in nesting order
-          if t.closesAt ≤ pos then
-            (true, { st with output := Output.closeSpan st.output, inTactic := ts })
-          else (false, st)
-        else
-          -- Close the message first
-          if needsClosing (text.toPosition pos) m then
-            (true, { st with output := Output.closeSpan st.output, inMessages := ms })
-          else (false, st)
-      else (true, { st with output := Output.closeSpan st.output, inMessages := ms })
+    | _ => (false, st)
 
   if more then closeUntil pos
 
@@ -944,14 +920,13 @@ This is used for splitting unparsed regions so that messages appear within the p
 def collectMessageBoundariesBetween (startPos endPos : Compat.String.Pos)
     : HighlightM (Compat.HashSet Compat.String.Pos) := do
   let text ← getFileMap
-  let { messages, nextMessage, inMessages, .. } ← get
+  let { messages, nextMessage, output, .. } ← get
   let mut boundaries : Compat.HashSet Compat.String.Pos := {}
-  -- Add in-range end positions of active messages:
-  for msg in inMessages do
-    if let some msgEndPos := msg.endPos then
-      let msgEndPosUtf8 := leanPosToUtf8Pos text msgEndPos
-      if msgEndPosUtf8 < endPos then
-        boundaries := boundaries.insert msgEndPosUtf8
+  -- Add in-range end positions of open message spans:
+  for frame in output do
+    if let .span _ _ (some e) := frame then
+      if e < endPos then
+        boundaries := boundaries.insert e
   -- Add in-range start and end positions of upcoming messages:
   if let some nextMessage := nextMessage then
     for msg in messages[nextMessage:] do

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -316,6 +316,11 @@ def infoExists [Monad m] [MonadLiftT IO m] (trees : Array InfoTree) (stx : Synta
   return false
 
 open Highlighted in
+/--
+A frame of the highlighter's output stack, which is a `List Output` with the innermost frame first.
+A frame is either an open message span or tactic region, which the code highlighted while it is
+open becomes part of, or the code accumulated at that depth.
+-/
 inductive Output where
   | seq (emitted : Array Highlighted)
   | span (info : Array Highlighted.Message) (startPos : Compat.String.Pos) (endPos : Option Compat.String.Pos)
@@ -433,6 +438,19 @@ def Output.closeSpan (output : List Output) : List Output :=
     | .seq left :: more =>
       go (.seq (left.push acc)) more
   go .empty output
+
+/-- Whether `frame` is an open message span or tactic region. -/
+def Output.isOpenRegion (frame : Output) : Bool :=
+  match frame with
+  | .span .. | .tactics .. => true
+  | .seq _ => false
+
+/-- Whether `frame` is an open region that ends at or before `pos`. -/
+def Output.endedAt (pos : Compat.String.Pos) (frame : Output) : Bool :=
+  match frame with
+  | .span _ _ endPos => endPos.all (· ≤ pos)
+  | .tactics _ _ endPos => endPos ≤ pos
+  | .seq _ => false
 
 def Highlighted.fromOutput (output : List Output) : Highlighted :=
   let rec go (acc : Highlighted) : List Output → Highlighted
@@ -574,7 +592,7 @@ private def modify? (f : α → Option α) : (xs : List α) → Option (List α)
       some (x' :: xs)
     else (x :: ·) <$> modify? f xs
 
-def HighlightState.openTactic (st : HighlightState) (info : Array (Highlighted.Goal Highlighted)) (startPos endPos : Compat.String.Pos) (_pos : Position) : HighlightState :=
+def HighlightState.openTactic (st : HighlightState) (info : Array (Highlighted.Goal Highlighted)) (startPos endPos : Compat.String.Pos) : HighlightState :=
   if let some out' := modify? update? st.output then
     {st with output := out'}
   else
@@ -587,8 +605,8 @@ where
       else none
     | _ => none
 
-def HighlightM.openTactic (info : Array (Highlighted.Goal Highlighted)) (startPos endPos : Compat.String.Pos) (pos : Position) : HighlightM Unit :=
-  modify fun st => st.openTactic info startPos endPos pos
+def HighlightM.openTactic (info : Array (Highlighted.Goal Highlighted)) (startPos endPos : Compat.String.Pos) : HighlightM Unit :=
+  modify fun st => st.openTactic info startPos endPos
 
 instance : Inhabited (HighlightM α) where
   default := fun _ _ _ => default
@@ -885,26 +903,14 @@ partial def openUntil (pos : Lean.Position) : HighlightM Unit := do
         }
       openUntil pos
 
-/--
-Closes the message spans and tactic regions that end at or before `pos`.
-
-`Output.closeSpan` always closes the innermost open frame, so frames close in nesting order:
-a region that has reached its end position while another region is still open inside it
-stays open until the inner one closes, which keeps overlapping regions properly nested. A
-message span with no end position closes as soon as it is the innermost open frame.
--/
+/-- Closes the message spans and tactic regions that end at or before `pos`, innermost first. -/
 partial def closeUntil (pos : Compat.String.Pos) : HighlightM Unit := do
   let more ← modifyGet fun st =>
-    match st.output.find? (fun | .span .. | .tactics .. => true | _ => false) with
-    | some (.span _ _ endPos) =>
-      if endPos.map (fun e => (e ≤ pos : Bool)) |>.getD true then
-        (true, {st with output := Output.closeSpan st.output})
+    match st.output.find? Output.isOpenRegion with
+    | some frame =>
+      if Output.endedAt pos frame then (true, {st with output := Output.closeSpan st.output})
       else (false, st)
-    | some (.tactics _ _ endPos) =>
-      if endPos ≤ pos then
-        (true, {st with output := Output.closeSpan st.output})
-      else (false, st)
-    | _ => (false, st)
+    | none => (false, st)
 
   if more then closeUntil pos
 
@@ -925,7 +931,7 @@ def collectMessageBoundariesBetween (startPos endPos : Compat.String.Pos)
   -- Add in-range end positions of open message spans:
   for frame in output do
     if let .span _ _ (some e) := frame then
-      if e < endPos then
+      if startPos ≤ e && e < endPos then
         boundaries := boundaries.insert e
   -- Add in-range start and end positions of upcoming messages:
   if let some nextMessage := nextMessage then
@@ -944,7 +950,7 @@ def collectMessageBoundariesBetween (startPos endPos : Compat.String.Pos)
           boundaries := boundaries.insert nextWhitespace
       if let some msgEndPos := msg.endPos then
         let msgEndPosUtf8 := leanPosToUtf8Pos text msgEndPos
-        if msgEndPosUtf8 ≤ endPos then
+        if startPos ≤ msgEndPosUtf8 && msgEndPosUtf8 ≤ endPos then
           -- If the message ends where it starts, run to the next whitespace
           if msgEndPosUtf8 == msgPosUtf8 then
             boundaries := boundaries.insert nextWhitespace
@@ -1424,31 +1430,29 @@ def highlightGoals (ci : ContextInfo) (goals : List MVarId) :
 def tacticInfoGoals
     (ci : ContextInfo) (tacticInfo : TacticInfo)
     (startPos endPos : Compat.String.Pos)
-    (endPosition : Position)
     (before : Bool := false) :
-    HighlightM (Array (Highlighted.Goal Highlighted) × Compat.String.Pos × Compat.String.Pos × Position) := do
+    HighlightM (Array (Highlighted.Goal Highlighted) × Compat.String.Pos × Compat.String.Pos) := do
   let goals := if before then tacticInfo.goalsBefore else tacticInfo.goalsAfter
   let ci := {ci with mctx := if before then tacticInfo.mctxBefore else tacticInfo.mctxAfter}
   let goalView ← highlightGoals ci goals
 
-  return (goalView, startPos, endPos, endPosition)
+  return (goalView, startPos, endPos)
 
 /--
 Finds the tactic info for `stx`, which should be in the indicated span.
 
-If found, returns the goals, the byte indices of the span, and the provided end position.
+If found, returns the goals and the byte indices of the span.
 -/
 partial def findTactics'
     (stx : Syntax)
     (startPos endPos : Compat.String.Pos)
-    (endPosition : Position)
     (before : Bool := false)
-    : HighlightM (Option (Array (Highlighted.Goal Highlighted) × Compat.String.Pos × Compat.String.Pos × Position)) := do
+    : HighlightM (Option (Array (Highlighted.Goal Highlighted) × Compat.String.Pos × Compat.String.Pos)) := do
 
   if let some res := (← readThe InfoTable).tacticInfo? stx then
     for (ci, tacticInfo) in res.reverse do
       if !before && !tacticInfo.goalsBefore.isEmpty && tacticInfo.goalsAfter.isEmpty then
-        return some (#[], startPos, endPos, endPosition)
+        return some (#[], startPos, endPos)
 
       let goals := if before then tacticInfo.goalsBefore else tacticInfo.goalsAfter
       let ci := {ci with mctx := if before then tacticInfo.mctxBefore else tacticInfo.mctxAfter}
@@ -1456,21 +1460,20 @@ partial def findTactics'
       let goalView ← highlightGoals ci goals
 
       if !Output.inTacticState (← get).output goalView then
-        return some (goalView, startPos, endPos, endPosition)
+        return some (goalView, startPos, endPos)
 
   return none
 
 /--
 Finds all the tactic info for `stx`, which should be in the indicated span.
 
-If found, returns the goals, the byte indices of the span, and the provided end position.
+If found, returns the goals and the byte indices of the span.
 -/
 partial def findAllTactics'
     (stx : Syntax)
     (startPos endPos : Compat.String.Pos)
-    (endPosition : Position)
     (before : Bool := false)
-    : HighlightM (Option (Array (Highlighted.Goal Highlighted) × Compat.String.Pos × Compat.String.Pos × Position)) := do
+    : HighlightM (Option (Array (Highlighted.Goal Highlighted) × Compat.String.Pos × Compat.String.Pos)) := do
 
   let mut found := #[]
 
@@ -1488,7 +1491,7 @@ partial def findAllTactics'
         found := found ++ goalView
 
   if found.isEmpty then return none
-  else return some (found, startPos, endPos, endPosition)
+  else return some (found, startPos, endPos)
 
 /--
 Finds the proof state _after_ a single rewrite rule `stx` (one entry of a `rw`/`rewrite` rule list).
@@ -1496,8 +1499,7 @@ This gives each step of `rw [h₁, …, hₙ]` its own intermediate proof state.
 -/
 partial def rwRuleGoals
     (trees : Array Lean.Elab.InfoTree) (stx : Syntax) :
-    HighlightM (Option (Array (Highlighted.Goal Highlighted) × Compat.String.Pos × Compat.String.Pos × Position)) := do
-  let text ← getFileMap
+    HighlightM (Option (Array (Highlighted.Goal Highlighted) × Compat.String.Pos × Compat.String.Pos)) := do
   let some ruleStart := stx.getPos? (canonicalOnly := true)
     | return none
   for t in trees do
@@ -1506,7 +1508,7 @@ partial def rwRuleGoals
         if let some regionStart := ti.stx.getPos? (canonicalOnly := true) then
           if let some regionEnd := ti.stx.getTailPos? (canonicalOnly := true) then
             if regionStart == ruleStart then
-              return some (← tacticInfoGoals ci ti regionStart regionEnd (text.toPosition regionEnd) (before := false))
+              return some (← tacticInfoGoals ci ti regionStart regionEnd (before := false))
   return none
 
 /-- Tactics which should show inner tactic scripts' states as well as the full final state -/
@@ -1516,14 +1518,12 @@ partial def findTactics
     (trees : Array Lean.Elab.InfoTree) -- TODO: use the table instead of these
     (stx : Syntax)
     (before : Bool := false)
-    : HighlightM (Option (Array (Highlighted.Goal Highlighted) × Compat.String.Pos × Compat.String.Pos × Position)) :=
+    : HighlightM (Option (Array (Highlighted.Goal Highlighted) × Compat.String.Pos × Compat.String.Pos)) :=
   withTraceNode `SubVerso.Highlighting.Code (fun x => pure m!"findTactics {stx} ==> {match x with | .error _ => "err" | .ok v => v.map (fun _ => "yes") |>.getD "no"}") <| do
-  let text ← getFileMap
   let some startPos := stx.getPos?
     | return none
   let some endPos := stx.getTailPos?
     | return none
-  let endPosition := text.toPosition endPos
 
   -- Blacklisted tactics. TODO: make into an extensible table.
   -- `;` is blacklisted  - no need to highlight states identically
@@ -1539,7 +1539,7 @@ partial def findTactics
           | `(Lean.Parser.Term.byTactic| by%$tk $tactics)
           | `(Lean.Parser.Term.byTactic'| by%$tk $tactics) =>
             if tk == stx then
-              let ts ← findTactics' tactics startPos endPos endPosition (before := true)
+              let ts ← findTactics' tactics startPos endPos (before := true)
               -- Macro tactics that embed a `by` (e.g. `have h := by …`) record the byTactic's
               -- tacticSeq with the *enclosing* goal as its `goalsBefore`, so the `by` token here
               -- would be labelled with the surrounding state rather than the subproof's. Such an
@@ -1560,7 +1560,7 @@ partial def findTactics
           if tacticInfo.stx.getKind == nullKind then
             if let some tacStx := tacticInfo.stx.getArgs.back? then
               if tacStx == stx then
-                return some (← tacticInfoGoals ci tacticInfo startPos endPos endPosition (before := true))
+                return some (← tacticInfoGoals ci tacticInfo startPos endPos (before := true))
 
           match tacticInfo.stx with
           | `(Lean.Parser.Tactic.inductionAlt| $_lhs =>%$tk $rhs )
@@ -1571,7 +1571,7 @@ partial def findTactics
           | `(tactic| case $_ $_* =>%$tk $rhs )
           | `(tactic| case' $_ $_* =>%$tk $rhs ) =>
             if tk == stx then
-              return (← findTactics' rhs startPos endPos endPosition (before := true))
+              return (← findTactics' rhs startPos endPos (before := true))
           | _ => continue
 
   -- Only show tactic output for the most specific source spans possible, with a few exceptions:
@@ -1591,7 +1591,7 @@ partial def findTactics
   if stx.getKind == ``Lean.Parser.Tactic.rwRule then
     return ← rwRuleGoals trees stx
 
-  findTactics' stx startPos endPos endPosition (before := before)
+  findTactics' stx startPos endPos (before := before)
 
 partial def highlightLevel (u : TSyntax `level) : HighlightM Unit := do
   match u with
@@ -1651,12 +1651,9 @@ where
 Get the goals before a piece of syntax.
 -/
 def beforeGoals (stx : Syntax) : HighlightM (Option (Array (Highlighted.Goal Highlighted))) := do
-  let text ← getFileMap
   if let some rstartPos := stx.getPos? then
     if let some rendPos := stx.getTailPos? then
-      let rendPosition := text.toPosition rendPos
-
-      if let some (goals, _, _, _) ← findAllTactics' stx rstartPos rendPos rendPosition (before := true) then
+      if let some (goals, _, _) ← findAllTactics' stx rstartPos rendPos (before := true) then
         return if !goals.isEmpty then some goals else none
   return none
 
@@ -1668,14 +1665,12 @@ def highlightArrowLike
     (lookingAt : Option (Name × Compat.String.Pos) := none) :
     HighlightM Unit := do
   let mut lhsTactics := tactics
-  let text ← getFileMap
   let rhsGoals ← beforeGoals rhs
 
   if let some goals := rhsGoals then
     if let some startPos := lhs.getPos? then
       if let some endPos := arr.getTailPos? then
-        let endPosition := text.toPosition endPos
-        HighlightM.openTactic goals startPos endPos endPosition
+        HighlightM.openTactic goals startPos endPos
         lhsTactics := false
 
   hl trees lhsTactics lookingAt lhs
@@ -1728,7 +1723,6 @@ def highlightSpecial
   | `(Lean.Parser.Tactic.inductionAlt|$lhs* =>%$arr $rhs) =>
     let mut lhsTactics := tactics
     -- Get the before state of the RHS
-    let text ← getFileMap
     let rhsGoals ← beforeGoals rhs
 
     -- Special handling for cases/induction alternatives. When there's one alt prior to =>, show the
@@ -1741,8 +1735,7 @@ def highlightSpecial
       if let some goals := rhsGoals then
         if let some startPos := lhs.raw.getPos? then
           if let some endPos := arr.getTailPos? then
-            let endPosition := text.toPosition endPos
-            HighlightM.openTactic goals startPos endPos endPosition
+            HighlightM.openTactic goals startPos endPos
             lhsTactics := false
 
       hl trees lhsTactics none lhs
@@ -1751,7 +1744,6 @@ def highlightSpecial
       for l in lhs do
         if let some startPos := l.raw.getPos? then
           if let some endPos := l.raw.getTailPos? then
-            let endPosition := text.toPosition endPos
             -- Starting in Lean 4.14, each case/tactic alt gets its own TacticInfo. This will
             -- highlight them appropriately. Older Lean versions will have less information here.
             for t in trees do
@@ -1761,9 +1753,9 @@ def highlightSpecial
                   if ti.stx.getKind == nullKind then
                     let preArr := i.stx[0]
                     if preArr.getKind == nullKind && preArr[0] == l then
-                      let (goals, _, _, _) ← tacticInfoGoals ci ti startPos endPos endPosition (before := true)
+                      let (goals, _, _) ← tacticInfoGoals ci ti startPos endPos (before := true)
                       if !goals.isEmpty then
-                        HighlightM.openTactic goals startPos endPos endPosition
+                        HighlightM.openTactic goals startPos endPos
                         lhsTactics := false
         hl trees lhsTactics none l
 
@@ -1771,8 +1763,7 @@ def highlightSpecial
       if let some goals := rhsGoals then
         if let some startPos := arr.getPos? then
           if let some endPos := arr.getTailPos? then
-          let endPosition := text.toPosition endPos
-          HighlightM.openTactic goals startPos endPos endPosition
+          HighlightM.openTactic goals startPos endPos
           hl trees false none arr
       else hl trees tactics none arr
 
@@ -1886,11 +1877,11 @@ partial def highlight'
   withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Highlighting {stx}") do
   let mut tactics := tactics
   if tactics then
-    if let some (tacticInfo, startPos, endPos, position) ← findTactics trees stx then
+    if let some (tacticInfo, startPos, endPos) ← findTactics trees stx then
       -- Drop a region that would just duplicate an enclosing region's state at its tail (e.g. the
       -- closing `]` of a `rw`, nested in a tactic region with the same final state).
       unless Output.tailDuplicatesOpen (← get).output tacticInfo endPos do
-        HighlightM.openTactic tacticInfo startPos endPos position
+        HighlightM.openTactic tacticInfo startPos endPos
         -- Tactic regions are normally leaves, so disable further search in the subtree. The
         -- exceptions are not leaves and keep their nested states:
         -- * `rw`/`rewrite`: each rewrite rule nests its own intermediate state inside the region.


### PR DESCRIPTION
The highlighter tracked open message spans and open tactic regions in two bookkeeping stacks beside the output frame stack, and `closeUntil` chose which stack to pop by comparing their heads. But `Output.closeSpan` always closes the innermost open frame, so when a message's range overlapped a tactic region improperly, the wrong frame was closed at the wrong position: a message ending partway into a region truncated the region there, and a message beginning partway into a region lost its tail at the region's end.

The output frames already carry their end positions, so the bookkeeping stacks are gone and the output itself determines what may close. Messages and proof regions close in nesting order: a region that reaches its end position while another region is still open inside it stays open until the inner one closes, so overlapping regions stay properly nested, extended to the enclosing close position instead of being cut off. In practice, they are well-nested in Lean.

The Lean language reference produces bit-identical output when built against this PR.