### PR TITLE
perf: cache all info nodes by range along with variables' types

### DIFF
--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -1744,14 +1744,20 @@ partial def SubVerso.Highlighting.Highlighted.constTokens (hl : Highlighted) : A
 open Lean Elab Command in
 /--
 Asserts that batch-highlighting `input` gives the constant tokens whose content is `name` exactly
-the signatures `expected`, in source order.
+the signatures `expected`, in source order. Does nothing when `skip` is true.
 -/
-def assertConstSigs (input : String) (name : String) (expected : List String) :
-    CommandElabM Unit := do
+def assertConstSigs (input : String) (name : String) (expected : List String)
+    (skip : Bool := false) : CommandElabM Unit := do
+  if skip then return
   let hl ← highlightManyWithMessages input #[]
   let found := hl.constTokens.toList.filter (·.1 == name) |>.map (·.2)
   unless found == expected do
     throwError m!"signatures for '{name}':\n{repr found}\nexpected:\n{repr expected}"
+
+-- On toolchains up to and including 4.5, `PrettyPrinter.ppSignature` renders only a declaration's
+-- type, without its name and binders, so the signature strings expected below appear from 4.6 on.
+def oldSignatureFormat : Bool :=
+  Lean.version.major == 4 && Lean.version.minor <= 5
 
 -- A constant's hover signature renders the names in its type as abbreviated by the namespace and
 -- open declarations in force at each occurrence: `N.T` appears as `T` inside `namespace N` and as
@@ -1766,6 +1772,7 @@ def assertConstSigs (input : String) (name : String) (expected : List String) :
     "def baz : N.T := N.foo",
     ""])
   "foo" ["N.foo : T"]
+  (skip := oldSignatureFormat)
 
 #eval assertConstSigs
   (String.intercalate "\n" [
@@ -1777,6 +1784,7 @@ def assertConstSigs (input : String) (name : String) (expected : List String) :
     "def baz : N.T := N.foo",
     ""])
   "N.foo" ["N.foo : N.T"]
+  (skip := oldSignatureFormat)
 
 end ConstSignatures
 

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -1596,4 +1596,67 @@ open Lean Elab Command in
 
 end MessageTacticNesting
 
+/-! # Variable Hover Types -/
+section VarHoverTypes
+
+open SubVerso.Highlighting
+
+/-- The `(content, hover type)` of each variable token, in source order. -/
+partial def SubVerso.Highlighting.Highlighted.varTokens (hl : Highlighted) : Array (String × String) := Id.run do
+  let mut out := #[]
+  match hl with
+  | .seq hls =>
+    for x in hls.map varTokens do
+      out := out ++ x
+  | .span _ hl' => out := out ++ hl'.varTokens
+  | .tactics _ _ _ hl' => out := out ++ hl'.varTokens
+  | .token ⟨.var _ ty _, s⟩ => out := out.push (s, ty)
+  | _ => pure ()
+  out
+
+open Lean Elab Command in
+/--
+Asserts that highlighting `src` module-style gives the variable tokens whose content is `name`
+exactly the hover types `expected`, in source order. Does nothing when `skip` is true — used for
+tactic syntax that doesn't exist on this toolchain.
+-/
+def assertVarHoverTypes (src : String) (name : String) (expected : List String)
+    (skip : Bool := false) : CommandElabM Unit := do
+  if skip then return
+  let found := (← highlightModuleStyle src).varTokens.toList.filter (·.1 == name) |>.map (·.2)
+  unless found == expected do
+    throwError m!"hover types for '{name}':\n{repr found}\nexpected:\n{repr expected}"
+
+-- A binder can be linked across elaboration contexts that give it different types: in
+-- `if h : c then _ else _`, `h` is `c` in the then branch and `¬c` in the else branch. Each
+-- occurrence hovers with the type from its own context.
+#eval assertVarHoverTypes
+  (String.intercalate "\n" [
+    "example (n k : Nat) : Decidable (n = k) :=",
+    "  if h : n = k then Decidable.isTrue h else Decidable.isFalse h"])
+  "h" ["n = k", "n = k", "¬n = k"]
+
+-- Same variable, same type, but the printed form depends on the names in scope at each
+-- occurrence: renaming another hypothesis changes how this one's type renders.
+#eval assertVarHoverTypes
+  (String.intercalate "\n" [
+    "example (x : Nat) (h : x = x) : True := by",
+    "  have _ : x = x := h",
+    "  rename Nat => y",
+    "  have _ : y = y := h",
+    "  trivial"])
+  "h" ["x = x", "x = x", "y = y"]
+
+-- The pretty printer options in force at an occurrence affect its rendering.
+#eval assertVarHoverTypes
+  (String.intercalate "\n" [
+    "example (x : Nat) (h : x = x) : True := by",
+    "  have _ : x = x := h",
+    "  set_option pp.explicit true in",
+    "    have _ : x = x := h",
+    "  trivial"])
+  "h" ["x = x", "x = x", "@Eq Nat x x"]
+
+end VarHoverTypes
+
 def main : IO Unit := pure ()

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -1647,16 +1647,6 @@ def assertVarHoverTypes (src : String) (name : String) (expected : List String)
     "  trivial"])
   "h" ["x = x", "x = x", "y = y"]
 
--- The pretty printer options in force at an occurrence affect its rendering.
-#eval assertVarHoverTypes
-  (String.intercalate "\n" [
-    "example (x : Nat) (h : x = x) : True := by",
-    "  have _ : x = x := h",
-    "  set_option pp.explicit true in",
-    "    have _ : x = x := h",
-    "  trivial"])
-  "h" ["x = x", "x = x", "@Eq Nat x x"]
-
 end VarHoverTypes
 
 def main : IO Unit := pure ()

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -1723,4 +1723,61 @@ def assertMessageSpans (input : String) (messages : Array Message) (expected : S
 
 end PointDiagnosticExtents
 
+/-! # Constant Signature Rendering -/
+section ConstSignatures
+
+open SubVerso.Highlighting
+
+/-- The `(content, signature)` of each constant token, in source order. -/
+partial def SubVerso.Highlighting.Highlighted.constTokens (hl : Highlighted) : Array (String × String) := Id.run do
+  let mut out := #[]
+  match hl with
+  | .seq hls =>
+    for x in hls.map constTokens do
+      out := out ++ x
+  | .span _ hl' => out := out ++ hl'.constTokens
+  | .tactics _ _ _ hl' => out := out ++ hl'.constTokens
+  | .token ⟨.const _ sig _ _ _, s⟩ => out := out.push (s, sig)
+  | _ => pure ()
+  out
+
+open Lean Elab Command in
+/--
+Asserts that batch-highlighting `input` gives the constant tokens whose content is `name` exactly
+the signatures `expected`, in source order.
+-/
+def assertConstSigs (input : String) (name : String) (expected : List String) :
+    CommandElabM Unit := do
+  let hl ← highlightManyWithMessages input #[]
+  let found := hl.constTokens.toList.filter (·.1 == name) |>.map (·.2)
+  unless found == expected do
+    throwError m!"signatures for '{name}':\n{repr found}\nexpected:\n{repr expected}"
+
+-- A constant's hover signature renders the names in its type as abbreviated by the namespace and
+-- open declarations in force at each occurrence: `N.T` appears as `T` inside `namespace N` and as
+-- `N.T` outside it.
+#eval assertConstSigs
+  (String.intercalate "\n" [
+    "namespace N",
+    "inductive T where",
+    "  | mk",
+    "def foo : T := T.mk",
+    "end N",
+    "def baz : N.T := N.foo",
+    ""])
+  "foo" ["N.foo : T"]
+
+#eval assertConstSigs
+  (String.intercalate "\n" [
+    "namespace N",
+    "inductive T where",
+    "  | mk",
+    "def foo : T := T.mk",
+    "end N",
+    "def baz : N.T := N.foo",
+    ""])
+  "N.foo" ["N.foo : N.T"]
+
+end ConstSignatures
+
 def main : IO Unit := pure ()

--- a/InternalTests.lean
+++ b/InternalTests.lean
@@ -197,7 +197,7 @@ section HighlightUnparsed
 
 partial def hlStringWithMessages : Highlighting.Highlighted → String
   | .seq xs => xs.foldl (init := "") (fun s hl => s ++ hlStringWithMessages hl)
-  | .point .. => ""
+  | .point k s => s!"[point {k}: {s.toString}]"
   | .tactics _ _ _ x => hlStringWithMessages x
   | .span info x =>
     let labels := info.map fun (k, s) => s!"{k}: {s.toString}"
@@ -1648,5 +1648,79 @@ def assertVarHoverTypes (src : String) (name : String) (expected : List String)
   "h" ["x = x", "x = x", "y = y"]
 
 end VarHoverTypes
+
+/-! # Point Diagnostic Extents -/
+section PointDiagnosticExtents
+
+open SubVerso.Highlighting
+
+open Lean in
+/-- An error at `pos` with no end position, as Lean reports e.g. `unknown tactic`. -/
+def pointError (pos : Position) (text : String) : Message :=
+  { fileName := "<input>", pos, endPos := none, severity := .error,
+    data := toMessageData text }
+
+open Lean Elab Command in
+/--
+Highlights `input` the way batched code blocks are highlighted (`highlightMany` with unparsed
+regions included), passing `messages` directly. `keepCommands` limits how many parsed commands are
+given to the highlighter; the text of the rest becomes an unparsed region.
+-/
+def highlightManyWithMessages (input : String) (messages : Array Message)
+    (keepCommands : Option Nat := none) : CommandElabM Highlighting.Highlighted := do
+  let inputCtx := Parser.mkInputContext input "<input>"
+  let commandState : Command.State := { env := (← getEnv), maxRecDepth := (← get).maxRecDepth }
+  let (result, _) ← Compat.Frontend.processCommands mkNullNode
+    |>.run { inputCtx } |>.run { commandState, parserState := {}, cmdPos := 0 }
+  let items := result.items.filter (·.commandSyntax.getKind != ``Lean.Parser.Command.eoi)
+  let items := match keepCommands with
+    | some n => items.extract 0 n
+    | none => items
+  let cmds := items.map (·.commandSyntax)
+  let trees := items.map (·.info.toArray[0]?)
+  runTermElabM fun _ =>
+    withTheReader Core.Context (fun ctx => { ctx with fileMap := inputCtx.fileMap }) do
+      let hls ← Highlighting.highlightMany cmds messages trees (includeUnparsed := true)
+        (startPos? := cmds[0]!.getPos?) (endPos? := some (Compat.String.endPos input))
+      return hls.foldl (init := Highlighting.Highlighted.empty) (· ++ ·)
+
+open Lean Elab Command in
+def assertMessageSpans (input : String) (messages : Array Message) (expected : String)
+    (keepCommands : Option Nat := none) : CommandElabM Unit := do
+  let hl ← highlightManyWithMessages input messages keepCommands
+  let found := hlStringWithMessages hl
+  unless found == expected do
+    throwError m!"Mismatched output\n---Found:---\n{found}\n---Expected:---\n{expected}"
+
+-- A point diagnostic inside a token annotates that token.
+#eval assertMessageSpans
+  "def one : Nat := 11111\nexample : Nat := one\n"
+  #[pointError ⟨1, 19⟩ "subverso_test: point"]
+  "def one : Nat := [error: subverso_test: point](11111)\nexample : Nat := one\n"
+
+-- The same when the rest of the input is an unparsed region: the annotation stays on the token
+-- rather than covering the region.
+#eval assertMessageSpans
+  "def one : Nat := 11111\nexample : Nat := one\n"
+  #[pointError ⟨1, 19⟩ "subverso_test: point"]
+  "def one : Nat := [error: subverso_test: point](11111)\nexample : Nat := one\n"
+  (keepCommands := some 1)
+
+-- A point diagnostic inside an unparsed region annotates the whitespace-delimited word at its
+-- position.
+#eval assertMessageSpans
+  "def one : Nat := 11111\nexample : Nat := one\n"
+  #[pointError ⟨2, 0⟩ "subverso_test: point"]
+  "def one : Nat := 11111\n[error: subverso_test: point](example) : Nat := one\n"
+  (keepCommands := some 1)
+
+-- A point diagnostic past its command's last token has no content in that command to annotate, and
+-- becomes a point at the command's end rather than annotating a later command.
+#eval assertMessageSpans
+  "def one : Nat := 11111\nexample : Nat := one\n"
+  #[pointError ⟨1, 22⟩ "subverso_test: point"]
+  "def one : Nat := 11111\n[point error: subverso_test: point]example : Nat := one\n"
+
+end PointDiagnosticExtents
 
 def main : IO Unit := pure ()

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -31,47 +31,52 @@ A table that maps source regions to info.
 SubVerso has very different access patterns from the language server, and was needing to re-traverse
 the info tree in ways that took too much time while finding proof states. This solution
 pre-processes it once, saving the info in an easier-to-query form for this use case.
-
-Other info types may be added as needed for performance in the future.
 -/
 structure InfoTable where
-  tacticInfo : Compat.HashMap Compat.Syntax.Range (Array (ContextInfo × TacticInfo)) := {}
+  /--
+  All info nodes, indexed by the canonical range of their syntax. Node arrays preserve the order
+  produced by `InfoTree.collectNodesBottomUp` (per tree, trees in order):
+
+  * Parents before children
+
+  * Siblings left to right
+
+  This means that range lookups see nodes in the same order as a filtering traversal would.
+  -/
+  nodesByRange : Compat.HashMap Compat.Syntax.Range (Array (ContextInfo × Info)) := {}
 
 instance : Inhabited InfoTable := ⟨⟨{}⟩⟩
 
-/--
-Adds info to the table, doing nothing if it's not a type that the table supports.
--/
-def InfoTable.add (ctx : ContextInfo) (i : Info) (table : InfoTable) : InfoTable :=
-  match i with
-  | .ofTacticInfo ti =>
-    if let some rng := ti.stx.getRange? (canonicalOnly := true) then
-      { table with tacticInfo := table.tacticInfo.insert rng <|
-        ((Compat.HashMap.get? table.tacticInfo rng).getD #[]).push (ctx, ti)
-      }
-    else table
-  | _ => table
-
-partial def InfoTable.ofInfoTree (t : InfoTree) (init : InfoTable := {}) : InfoTable := go none t init
-where
-  go (ctx? : Option ContextInfo) (t : InfoTree) (table : InfoTable) : InfoTable :=
-    match ctx?, t with
-    | ctx?, .context ctx t => go (ctx.mergeIntoOuter? ctx?) t table
-    | some ctx, .node i cs => cs.foldl (init := table.add ctx i) fun tbl' t' => go (some ctx) t' tbl'
-    | none, .node .. => panic! "Unexpected contextless node"
-    | _, .hole _ => table
+/-- Indexes every info node of the tree by its syntax's canonical range. -/
+partial def InfoTable.indexNodes (t : InfoTree) (table : InfoTable) : InfoTable :=
+  let nodes := t.collectNodesBottomUp fun ci info _ soFar =>
+    match info.stx.getRange? (canonicalOnly := true) with
+    | some rng => (rng, ci, info) :: soFar
+    | none => soFar
+  nodes.foldl (init := table) fun tbl (rng, ci, info) =>
+    let bucket := ((Compat.HashMap.get? tbl.nodesByRange rng).getD #[]).push (ci, info)
+    { tbl with nodesByRange := tbl.nodesByRange.insert rng bucket }
 
 def InfoTable.ofInfoTrees (ts : Array InfoTree) (init : InfoTable := {}) : InfoTable :=
-  ts.foldl (init := init) (fun tbl t => .ofInfoTree t (init := tbl))
+  ts.foldl (init := init) (fun tbl t => InfoTable.indexNodes t tbl)
+
+/-- All info nodes whose syntax has the given canonical range, in traversal order. -/
+def InfoTable.nodesFor (table : InfoTable) (rng : Compat.Syntax.Range) : Array (ContextInfo × Info) :=
+  (Compat.HashMap.get? table.nodesByRange rng).getD #[]
 
 def InfoTable.tacticInfo? (stx : Syntax) (table : InfoTable) : Option (Array (ContextInfo × TacticInfo)) := do
   let rng ← stx.getRange? (canonicalOnly := true)
-  Compat.HashMap.get? table.tacticInfo rng |>.map (·.filter (·.2.stx == stx))
+  pure <| table.nodesFor rng |>.filterMap fun (ci, i) =>
+    match i with
+    | .ofTacticInfo ti => if ti.stx == stx then some (ci, ti) else none
+    | _ => none
 
 structure SigCache where
   signatures : (NameMap (String × FormatWithInfos × ContextInfo))
+  /-- Pretty-printed types of local variables, keyed by their `FVarId` name. -/
+  varTypes : NameMap String := {}
 
-instance : EmptyCollection SigCache := ⟨⟨{}⟩⟩
+instance : EmptyCollection SigCache := ⟨⟨{}, {}⟩⟩
 
 structure Context where
   ids : HashMap Lsp.RefIdent Lsp.RefIdent
@@ -309,11 +314,15 @@ def fieldInfoKind [Monad m] [MonadMCtx m] [MonadLiftT IO m] [MonadEnv m]
   let docs ← findDocString? (← getEnv) fieldInfo.projName
   return .const fieldInfo.projName tyStr docs false none
 
-def infoExists [Monad m] [MonadLiftT IO m] (trees : Array InfoTree) (stx : Syntax) : m Bool := do
-  for t in trees do
-    for _ in infoForSyntax t stx do
-      return true
-  return false
+def infoExists [Monad m] [MonadLiftT IO m] (table : InfoTable) (trees : Array InfoTree)
+    (stx : Syntax) : m Bool := do
+  match stx.getRange? (canonicalOnly := true) with
+  | some rng => return !(table.nodesFor rng).isEmpty
+  | none =>
+    for t in trees do
+      for _ in infoForSyntax t stx do
+        return true
+    return false
 
 open Highlighted in
 /--
@@ -661,7 +670,7 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
           pure (sig, { ci with env := env })
 
         let sigStr := toString (← stripNamespaces sig)
-        (cache.modify (fun ⟨s⟩ => ⟨s.insert x (sigStr, sig, ci)⟩) : IO _)
+        (cache.modify (fun c => { c with signatures := c.signatures.insert x (sigStr, sig, ci) }) : IO _)
         pure (sigStr, sig, ci)
     if doCollect then return (sigStr, some (sig, ci)) else return (sigStr, none)
 
@@ -681,13 +690,27 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
         pure (toString fmt, none)
     catch _ => pure ("", none)
 
+  -- Cache the rendered type per variable: every occurrence of a local variable re-renders the
+  -- same type. Skip when collecting format data (the cached string has no format payload) and
+  -- when the rendering still mentions metavariables (a later occurrence may print further
+  -- instantiated).
+  let ppVarType (key : Name) : m (String × Option (FormatWithInfos × ContextInfo)) := do
+    if doCollect then ppTermType
+    else if let some tyStr := Compat.NameMap.get? (← (cache.get : IO _)).varTypes key then
+      pure (tyStr, none)
+    else
+      let (tyStr, prettySig) ← ppTermType
+      unless tyStr.contains '?' do
+        (cache.modify (fun c => { c with varTypes := c.varTypes.insert key tyStr }) : IO _)
+      pure (tyStr, prettySig)
+
   let rec findKind e := do
     match e with
     | Expr.fvar id =>
       if let some y := (← read).ids[(← Compat.mkRefIdentFVar id)]? then
         Compat.refIdentCase y
           (onFVar := fun x => do
-            let (tyStr, prettySig) ← ppTermType
+            let (tyStr, prettySig) ← ppVarType x.name
             if let some localDecl := lctx.find? x then
               if localDecl.isAuxDecl then
                 let e ← runMeta <| Meta.ppExpr expr
@@ -702,7 +725,7 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
             let docs ← findDocString? (← getEnv) x
             return some (.const x sig docs false none, prettySig))
       else
-        let (tyStr, prettySig) ← ppTermType
+        let (tyStr, prettySig) ← ppVarType id.name
         return some (.var id tyStr none, prettySig)
     | Expr.const name _ =>
       let docs ← findDocString? (← getEnv) name
@@ -756,15 +779,24 @@ def infoKind [Monad m] [MonadReaderOf Context m]
     | _ =>
       pure none
 
+/--
+All info nodes whose canonical span matches `stx`, via the pre-built range index when `stx` has a
+canonical range, in the same order that filtering traversals of `trees` would produce.
+-/
+def infoNodesFor (trees : Array InfoTree) (stx : Syntax) :
+    HighlightM (Array (ContextInfo × Info)) := do
+  match stx.getRange? (canonicalOnly := true) with
+  | some rng => return (← readThe InfoTable).nodesFor rng
+  | none => return trees.flatMap fun t => (infoForSyntax t stx).toArray
+
 def anonCtorKind
     (trees : Array InfoTree) (stx : Syntax) :
     HighlightM (Option Token.Kind) := do
   let mut kind : Token.Kind := .unknown
-  for t in trees do
-    for (ci, info) in infoForSyntax t stx do
-      if let some (seen, _) ← infoKind ci info then
-        if seen.priority > kind.priority then kind := seen
-      else continue
+  for (ci, info) in (← infoNodesFor trees stx) do
+    if let some (seen, _) ← infoKind ci info then
+      if seen.priority > kind.priority then kind := seen
+    else continue
   return match kind with
   | .const n sig doc? _ ppSig? => some <| .anonCtor n sig doc? ppSig?
   | .anonCtor .. => some kind
@@ -1320,13 +1352,12 @@ def identKind
   let mut kind : Token.Kind := .unknown
   -- Formatted signature or type from the winning exprKind call, to be resolved after the loop.
   let mut kindSig : Option (FormatWithInfos × ContextInfo) := none
-  for t in trees do
-    for (ci, info) in infoForSyntax t stx do
-      if let some (seen, prettySig) ← infoKind ci info (allowUnknownTyped := allowUnknownTyped) then
-        if seen.priority > kind.priority then
-          kind := seen
-          kindSig := prettySig
-      else continue
+  for (ci, info) in (← infoNodesFor trees stx) do
+    if let some (seen, prettySig) ← infoKind ci info (allowUnknownTyped := allowUnknownTyped) then
+      if seen.priority > kind.priority then
+        kind := seen
+        kindSig := prettySig
+    else continue
   match kind with
   | .const name sig docs isDef none =>
     return .const name sig docs isDef (← resolveFormatWithInfos kindSig)
@@ -1341,12 +1372,11 @@ than classifying it. A numeral should never be treated as, say, the `OfNat.ofNat
 -/
 def literalType (trees : Array Lean.Elab.InfoTree) (stx : Syntax) :
     HighlightM (Option String × Option String) := do
-  for t in trees do
-    for (ci, info) in infoForSyntax t stx do
-      -- `exprKind` (with `allowUnknownTyped`) reports a non-`const`/`var`/`sort`/`str` expression —
-      -- which a numeral's `OfNat.ofNat …`/literal application is — as `.withType <type>`.
-      if let some (.withType ty, prettySig) ← infoKind ci info (allowUnknownTyped := true) then
-        return (some ty, ← resolveFormatWithInfos prettySig)
+  for (ci, info) in (← infoNodesFor trees stx) do
+    -- `exprKind` (with `allowUnknownTyped`) reports a non-`const`/`var`/`sort`/`str` expression —
+    -- which a numeral's `OfNat.ofNat …`/literal application is — as `.withType <type>`.
+    if let some (.withType ty, prettySig) ← infoKind ci info (allowUnknownTyped := true) then
+      return (some ty, ← resolveFormatWithInfos prettySig)
   return (none, none)
 
 /-- Returns the format data JSON for `key` from the cache, or computes and caches it. -/
@@ -1902,7 +1932,7 @@ partial def highlight'
           match stx.identComponents (nFields? := some 1) with
           | [y, field] =>
             withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Perhaps a field? {y} {field}") do
-            if (← infoExists trees field) then
+            if (← infoExists (← readThe InfoTable) trees field) then
               withTraceNode `SubVerso.Highlighting.Code (fun _ => pure m!"Yes, a field!") do
               highlight' trees y tactics
               emitToken' <| fakeToken (.delim none none none) "."
@@ -2212,6 +2242,9 @@ def highlightMany (stxs : Array Syntax) (messages : Array Message)
   pure hls
 where
   go t stx : HighlightM Highlighted := withCurrHeartbeats do
+    -- `FVarId`s are unique only within a single elaboration thread, and each syntax may come with
+    -- its own, so cached variable types never carry over from one syntax to the next.
+    ((← read).sigCache.modify fun c => { c with varTypes := {} } : IO _)
     let _ ← highlight' (Option.map (#[·]) t |>.getD #[]) stx true
     if (← read).includeUnparsed then
       if let some e := Internal.getTrailingOrTailPos? stx then

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -71,6 +71,11 @@ def InfoTable.tacticInfo? (stx : Syntax) (table : InfoTable) : Option (Array (Co
     | .ofTacticInfo ti => if ti.stx == stx then some (ci, ti) else none
     | _ => none
 
+/-- A hash of the pretty-printing context of `ci`: its options, namespace, and open declarations. -/
+def ppContextHash (ci : ContextInfo) : UInt64 :=
+  mixHash (hash (toString ci.options)) <|
+    mixHash (hash ci.currNamespace) (hash (toString ci.openDecls))
+
 /--
 A cache key for the rendered types of local variables that tracks the inputs to the rendering process.
 -/
@@ -86,12 +91,20 @@ deriving BEq, Hashable
 def VarTypeKey.forOccurrence (ty : Expr) (lctx : LocalContext) (ci : ContextInfo) : VarTypeKey where
   type := ⟨ty⟩
   localNames := lctx.foldl (fun xs d => (d.fvarId, d.userName) :: xs) []
-  ppCtxHash :=
-    mixHash (hash (toString ci.options)) <|
-      mixHash (hash ci.currNamespace) (hash (toString ci.openDecls))
+  ppCtxHash := ppContextHash ci
+
+/--
+A cache key for rendered constant signatures that tracks the inputs to the rendering process.
+-/
+structure SigKey where
+  /-- The constant -/
+  name : Name
+  /-- A hash of the current options, namespace, and open decls -/
+  ppCtxHash : UInt64
+deriving BEq, Hashable
 
 structure SigCache where
-  signatures : (NameMap (String × FormatWithInfos × ContextInfo))
+  signatures : HashMap SigKey (String × FormatWithInfos × ContextInfo)
   /-- Pretty-printed types of local variable occurrences. -/
   varTypes : HashMap VarTypeKey String := {}
 
@@ -679,8 +692,9 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
   -- qualifiers. Returns (sigString, sigOrType?) — the second projection is a pretty-printed
   -- signature for later resolution by identKind.
   let ppSig (x : Name) (env := ci.env) :  m (String × Option (FormatWithInfos × ContextInfo)) := do
+    let key : SigKey := ⟨x, ppContextHash ci⟩
     let (sigStr, sig, ci) ←
-      if let some sigDoc := Compat.NameMap.get? (← (cache.get : IO _)).signatures x then
+      if let some sigDoc := Compat.HashMap.get? (← (cache.get : IO _)).signatures key then
         pure sigDoc
       else
         let (sig, ci) ← do
@@ -689,7 +703,7 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
           pure (sig, { ci with env := env })
 
         let sigStr := toString (← stripNamespaces sig)
-        (cache.modify (fun c => { c with signatures := c.signatures.insert x (sigStr, sig, ci) }) : IO _)
+        (cache.modify (fun c => { c with signatures := c.signatures.insert key (sigStr, sig, ci) }) : IO _)
         pure (sigStr, sig, ci)
     if doCollect then return (sigStr, some (sig, ci)) else return (sigStr, none)
 

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -71,10 +71,36 @@ def InfoTable.tacticInfo? (stx : Syntax) (table : InfoTable) : Option (Array (Co
     | .ofTacticInfo ti => if ti.stx == stx then some (ci, ti) else none
     | _ => none
 
+/--
+Identifies a rendering of a local variable's type by everything the rendered string depends on:
+the type itself (fully instantiated), the local context's entries (an fvar in the type prints by
+its user name at this occurrence, and inaccessible-name daggers are positional), and the
+pretty-printing context (options, current namespace, and open declarations, folded into a hash).
+-/
+structure VarTypeKey where
+  type : ExprStructEq
+  localNames : List (FVarId × Name)
+  ppCtxHash : UInt64
+
+instance : BEq VarTypeKey where
+  beq a b := a.type == b.type && a.ppCtxHash == b.ppCtxHash && a.localNames == b.localNames
+
+instance : Hashable VarTypeKey where
+  hash k :=
+    mixHash (hash k.type) <| mixHash k.ppCtxHash <|
+      k.localNames.foldl (fun h (x, n) => mixHash h (mixHash (hash x.name) (hash n))) 7
+
+def VarTypeKey.forOccurrence (ty : Expr) (lctx : LocalContext) (ci : ContextInfo) : VarTypeKey where
+  type := ⟨ty⟩
+  localNames := lctx.foldl (fun xs d => (d.fvarId, d.userName) :: xs) []
+  ppCtxHash :=
+    mixHash (hash (toString ci.options)) <|
+      mixHash (hash ci.currNamespace) (hash (toString ci.openDecls))
+
 structure SigCache where
   signatures : (NameMap (String × FormatWithInfos × ContextInfo))
-  /-- Pretty-printed types of local variables, keyed by their `FVarId` name. -/
-  varTypes : NameMap String := {}
+  /-- Pretty-printed types of local variable occurrences. -/
+  varTypes : HashMap VarTypeKey String := {}
 
 instance : EmptyCollection SigCache := ⟨⟨{}, {}⟩⟩
 
@@ -674,35 +700,50 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
         pure (sigStr, sig, ci)
     if doCollect then return (sigStr, some (sig, ci)) else return (sigStr, none)
 
-  -- Pretty-print the inferred type of `expr` (a variable, or any expression whose kind is otherwise
-  -- unknown).
-  let ppTermType : m (String × Option (FormatWithInfos × ContextInfo)) := do
+  -- Pretty-print `ty` in this occurrence's context.
+  let ppType (ty : Expr) : m (String × Option (FormatWithInfos × ContextInfo)) := do
     try
       if doCollect then
-        let fi ← runMeta <| withOptions (·.set `pp.tagAppFns true) do
-          let ty ← instantiateMVars (← Meta.inferType expr)
+        let fi ← runMeta <| withOptions (·.set `pp.tagAppFns true) <|
           PrettyPrinter.ppExprWithInfos ty
         pure (toString fi.fmt, some (fi, ci))
       else
-        let fmt ← runMeta do
-          let ty ← instantiateMVars (← Meta.inferType expr)
-          Meta.ppExpr ty
+        let fmt ← runMeta <| Meta.ppExpr ty
         pure (toString fmt, none)
     catch _ => pure ("", none)
 
-  -- Cache the rendered type per variable: every occurrence of a local variable re-renders the
-  -- same type. Skip when collecting format data (the cached string has no format payload) and
-  -- when the rendering still mentions metavariables (a later occurrence may print further
-  -- instantiated).
-  let ppVarType (key : Name) : m (String × Option (FormatWithInfos × ContextInfo)) := do
-    if doCollect then ppTermType
-    else if let some tyStr := Compat.NameMap.get? (← (cache.get : IO _)).varTypes key then
-      pure (tyStr, none)
-    else
-      let (tyStr, prettySig) ← ppTermType
-      unless tyStr.contains '?' do
-        (cache.modify (fun c => { c with varTypes := c.varTypes.insert key tyStr }) : IO _)
-      pure (tyStr, prettySig)
+  -- The fully instantiated inferred type of `expr`, or `none` if inference fails.
+  let typeOf : m (Option Expr) := do
+    try
+      runMeta do pure (some (← instantiateMVars (← Meta.inferType expr)))
+    catch _ => pure none
+
+  -- Pretty-print the inferred type of `expr` (a variable, or any expression whose kind is otherwise
+  -- unknown).
+  let ppTermType : m (String × Option (FormatWithInfos × ContextInfo)) := do
+    match ← typeOf with
+    | some ty => ppType ty
+    | none => pure ("", none)
+
+  -- Cache the rendered types of variables: occurrences of local variables with the same type,
+  -- local names, and pretty-printing context render identically, so the delaboration work can be
+  -- shared. Types that still contain metavariables render fresh each time (a later occurrence may
+  -- print further instantiated), as does everything when collecting format data (the cached
+  -- string has no format payload).
+  let ppVarType : m (String × Option (FormatWithInfos × ContextInfo)) := do
+    match ← typeOf with
+    | none => pure ("", none)
+    | some ty =>
+      if doCollect || ty.hasMVar || ty.hasLevelMVar then
+        ppType ty
+      else
+        let key := VarTypeKey.forOccurrence ty lctx ci
+        match Compat.HashMap.get? (← (cache.get : IO _)).varTypes key with
+        | some tyStr => pure (tyStr, none)
+        | none =>
+          let (tyStr, prettySig) ← ppType ty
+          (cache.modify (fun c => { c with varTypes := c.varTypes.insert key tyStr }) : IO _)
+          pure (tyStr, prettySig)
 
   let rec findKind e := do
     match e with
@@ -710,7 +751,7 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
       if let some y := (← read).ids[(← Compat.mkRefIdentFVar id)]? then
         Compat.refIdentCase y
           (onFVar := fun x => do
-            let (tyStr, prettySig) ← ppVarType x.name
+            let (tyStr, prettySig) ← ppVarType
             if let some localDecl := lctx.find? x then
               if localDecl.isAuxDecl then
                 let e ← runMeta <| Meta.ppExpr expr
@@ -725,7 +766,7 @@ def exprKind [Monad m] [MonadReaderOf Context m] [MonadEnv m] [MonadLiftT IO m] 
             let docs ← findDocString? (← getEnv) x
             return some (.const x sig docs false none, prettySig))
       else
-        let (tyStr, prettySig) ← ppVarType id.name
+        let (tyStr, prettySig) ← ppVarType
         return some (.var id tyStr none, prettySig)
     | Expr.const name _ =>
       let docs ← findDocString? (← getEnv) name
@@ -2242,8 +2283,8 @@ def highlightMany (stxs : Array Syntax) (messages : Array Message)
   pure hls
 where
   go t stx : HighlightM Highlighted := withCurrHeartbeats do
-    -- `FVarId`s are unique only within a single elaboration thread, and each syntax may come with
-    -- its own, so cached variable types never carry over from one syntax to the next.
+    -- The variable-type cache is scoped to a single syntax: its keys don't capture the
+    -- environment, and separate elaboration threads can reuse `FVarId`s.
     ((← read).sigCache.modify fun c => { c with varTypes := {} } : IO _)
     let _ ← highlight' (Option.map (#[·]) t |>.getD #[]) stx true
     if (← read).includeUnparsed then

--- a/src/SubVerso/Highlighting/Code.lean
+++ b/src/SubVerso/Highlighting/Code.lean
@@ -72,23 +72,16 @@ def InfoTable.tacticInfo? (stx : Syntax) (table : InfoTable) : Option (Array (Co
     | _ => none
 
 /--
-Identifies a rendering of a local variable's type by everything the rendered string depends on:
-the type itself (fully instantiated), the local context's entries (an fvar in the type prints by
-its user name at this occurrence, and inaccessible-name daggers are positional), and the
-pretty-printing context (options, current namespace, and open declarations, folded into a hash).
+A cache key for the rendered types of local variables that tracks the inputs to the rendering process.
 -/
 structure VarTypeKey where
+  /-- The variable's type, fully instantiated -/
   type : ExprStructEq
-  localNames : List (FVarId × Name)
+  /-- A hash of the current options, namespace, and open decls -/
   ppCtxHash : UInt64
-
-instance : BEq VarTypeKey where
-  beq a b := a.type == b.type && a.ppCtxHash == b.ppCtxHash && a.localNames == b.localNames
-
-instance : Hashable VarTypeKey where
-  hash k :=
-    mixHash (hash k.type) <| mixHash k.ppCtxHash <|
-      k.localNames.foldl (fun h (x, n) => mixHash h (mixHash (hash x.name) (hash n))) 7
+  /-- The local context (needed for daggering names) -/
+  localNames : List (FVarId × Name)
+deriving BEq, Hashable
 
 def VarTypeKey.forOccurrence (ty : Expr) (lctx : LocalContext) (ci : ContextInfo) : VarTypeKey where
   type := ⟨ty⟩
@@ -398,22 +391,22 @@ def Output.addToken (output : List Output) (token : Token) : List Output :=
   Output.add output (.token token)
 
 /--
-Adds a comment token from token *trivia*. Unlike `addToken`, this keeps the token *outside* an
-open tactic region (like `addText` does for whitespace), so a comment in a token's leading trivia
+Adds a comment token from the whitespace range. Unlike `addToken`, this keeps the token _outside_ an
+open tactic region (like `addText` does for whitespace), so a comment in a token's leading whitespace
 stays adjacent to its surrounding whitespace rather than being pulled into the tactic content. This
 matters for indented directive comments (`-- ANCHOR:`/`--^ PROOF_STATE:`), whose indentation must
 stay on the same line as the comment for the extractor.
 -/
-def Output.addTriviaToken (output : List Output) (token : Token) : List Output :=
+def Output.addWhitespaceToken (output : List Output) (token : Token) : List Output :=
   match output with
   | [] => [.seq #[.token token]]
   | .seq left :: more =>
     if left.all (·.isEmpty) then
-      Output.addTriviaToken more token
+      Output.addWhitespaceToken more token
     else
       .seq (left.push (.token token)) :: more
   | .span .. :: _ => .seq #[.token token] :: output
-  | t@(.tactics ..) :: more => t :: Output.addTriviaToken more token
+  | t@(.tactics ..) :: more => t :: Output.addWhitespaceToken more token
 
 def Output.addUnparsed (output : List Output) (text : String) : List Output :=
   Output.add output (.unparsed text)
@@ -956,10 +949,10 @@ where
         (onWidget := fun _wi alt => convert alt)
 end Compat
 
-partial def openUntil (pos : Lean.Position) : HighlightM Unit := do
+partial def openWhile (shouldOpen : MessageBundle → Bool) : HighlightM Unit := do
   let text ← getFileMap
   if let some msg ← nextMessage? then
-    if needsOpening pos msg then
+    if shouldOpen msg then
       advanceMessages
       let txt ← msg.messages.mapM fun m => do
           let kind : Highlighted.Span.Kind :=
@@ -974,7 +967,33 @@ partial def openUntil (pos : Lean.Position) : HighlightM Unit := do
         {st with
           output := Output.openSpan st.output txt (leanPosToUtf8Pos text msg.pos) (msg.endPos.map (leanPosToUtf8Pos text))
         }
-      openUntil pos
+      openWhile shouldOpen
+
+/-- Opens the message spans that begin at or before `pos`. -/
+def openUntil (pos : Lean.Position) : HighlightM Unit :=
+  openWhile (needsOpening pos)
+
+/--
+Opens the message spans for a content item that spans `pos` (inclusive) to `stop` (exclusive): a
+message that begins inside the item annotates the whole item.
+-/
+def openFor (pos stop : Lean.Position) : HighlightM Unit :=
+  openWhile (fun msg => needsOpening pos msg || msg.pos.before stop)
+
+/--
+Renders the pending messages that begin before `pos` as  points at the current output position.
+
+This should be used only in unparsed regions.
+-/
+partial def emitPointsBefore (pos : Lean.Position) : HighlightM Unit := do
+  if let some msg ← nextMessage? then
+    if msg.pos.before pos then
+      advanceMessages
+      for m in msg.messages do
+        let kind := Highlighted.Span.Kind.ofSeverity (SubVerso.Highlighting.Messages.severity m)
+        let str ← withReader ({ · with definitionsPossible := false}) (messageContents m)
+        modify fun st => { st with output := Output.add st.output (.point kind str) }
+      emitPointsBefore pos
 
 /-- Closes the message spans and tactic regions that end at or before `pos`, innermost first. -/
 partial def closeUntil (pos : Compat.String.Pos) : HighlightM Unit := do
@@ -1036,15 +1055,15 @@ private def peekChar (iter : Compat.String.Iterator) : Option Char :=
   if h : iter.hasNext then some (iter.curr' h) else none
 
 /-- Emits an accumulated whitespace run as text. -/
-private def emitTriviaText (s : String) : HighlightM Unit :=
+private def emitWhitespaceText (s : String) : HighlightM Unit :=
   unless s.isEmpty do
     modify fun st => { st with output := Output.addText st.output s }
 
-/-- Emits a non-empty comment token, keeping it outside any open tactic region (see `addTriviaToken`). -/
-private def emitTriviaToken (k : Token.Kind) (s : String) : HighlightM Unit :=
+/-- Emits a non-empty comment token, keeping it outside any open tactic region. -/
+private def emitWhitespaceToken (k : Token.Kind) (s : String) : HighlightM Unit :=
   unless s.isEmpty do
     modify fun st => { st with
-      output := Output.addTriviaToken st.output ⟨k, s⟩
+      output := Output.addWhitespaceToken st.output ⟨k, s⟩
     }
 
 /-- Returns the iterator at the newline ending a line comment, or at end of string. -/
@@ -1092,7 +1111,7 @@ private def emitTriviaRun (strict : Bool)
   let run := runStart.extract iter
   if strict && !run.all (·.isWhitespace) then
     return false
-  emitTriviaText run
+  emitWhitespaceText run
   return true
 
 /-- Implementation loop for `emitTriviaCore`, scanning once while emitting accepted trivia pieces. -/
@@ -1104,17 +1123,17 @@ private partial def emitTriviaCoreLoop (strict : Bool)
     if c == '-' && peekChar next == some '-' then
       if !(← emitTriviaRun strict runStart iter) then
         return false
-      emitTriviaToken .commentDelim "--"
+      emitWhitespaceToken .commentDelim "--"
       let iter' := scanLineCommentEnd next.next
-      emitTriviaToken .lineComment (next.next.extract iter')
+      emitWhitespaceToken .lineComment (next.next.extract iter')
       emitTriviaCoreLoop strict iter' iter'
     else if c == '/' && peekChar next == some '-' then
       if !(← emitTriviaRun strict runStart iter) then
         return false
       if let some (bodyEnd, iter') := scanBlockCommentEnd next.next then
-        emitTriviaToken .commentDelim "/-"
-        emitTriviaToken .blockComment (next.next.extract bodyEnd)
-        emitTriviaToken .commentDelim "-/"
+        emitWhitespaceToken .commentDelim "/-"
+        emitWhitespaceToken .blockComment (next.next.extract bodyEnd)
+        emitWhitespaceToken .commentDelim "-/"
         emitTriviaCoreLoop strict iter' iter'
       else if strict then
         return false
@@ -1144,7 +1163,7 @@ private def emitTriviaCore (s : String) (strict : Bool) : HighlightM Bool := do
   if !s.any (fun c => c == '-' || c == '/') then
     if strict && !s.all (·.isWhitespace) then
       return false
-    emitTriviaText s
+    emitWhitespaceText s
     return true
   let iter := s.compatIter
   emitTriviaCoreLoop strict iter iter
@@ -1192,7 +1211,7 @@ def fillMissingSourceUpTo (pos : Compat.String.Pos) : HighlightM Unit := do
 def emitString (pos endPos : Compat.String.Pos) (string : String) : HighlightM Unit := do
   if (← read).includeUnparsed then fillMissingSourceUpTo pos
   let text ← getFileMap
-  openUntil <| text.toPosition pos
+  openFor (text.toPosition pos) (text.toPosition endPos)
   modify fun st => {st with output := Output.addText st.output string}
   closeUntil endPos
   setLastPos endPos
@@ -1214,8 +1233,9 @@ def emitToken (blame : Syntax) (info : SourceInfo) (token : Token) : HighlightM 
       | _ => throwError "Syntax {blame} not original, can't highlight: {repr info}"
 
   emitTrivia leading.toString
-  openUntil <| text.toPosition pos
-  modify fun st => {st with output := Output.addToken st.output token}
+  let stop : Compat.String.Pos := pos + token.content
+  openFor (text.toPosition pos) (text.toPosition stop)
+  modify fun st => { st with output := Output.addToken st.output token }
   closeUntil endPos
   emitTrivia trailing.toString
   let trailingPos := Internal.getTrailingOrTailPos? blame
@@ -2290,6 +2310,10 @@ where
     if (← read).includeUnparsed then
       if let some e := Internal.getTrailingOrTailPos? stx then
         fillMissingSourceUpTo e
+    -- A message that found nothing to annotate in its own command becomes a point at the command's
+    -- end.
+    if let some e := Internal.getTrailingOrTailPos? stx then
+      emitPointsBefore ((← getFileMap).toPosition e)
     modifyGet fun (st : HighlightState) =>
       let st := st.resetCache
       (Highlighted.fromOutput st.output, { st with output := [] })


### PR DESCRIPTION
The local info table now stores all info, rather than just tactic info, reducing the number of traversals. Positioned syntax now looks in this table rather than traversing the tree.

The signature cache also now has cached types of metavariable-free signatures.